### PR TITLE
Added a script to create a desktop entry in Linux systems

### DIFF
--- a/Create-Desktop-Entry
+++ b/Create-Desktop-Entry
@@ -1,0 +1,28 @@
+#!/bin/sh
+
+# Adds a desktop entry for the current user
+
+NAME="Popcorn Time"
+COMMENT="Watch Movies and TV Shows instantly!"
+
+CURRENT_DIR=$(pwd)
+EXECUTABLE=$CURRENT_DIR/Popcorn-Time
+ICON_PATH=$CURRENT_DIR/src/app/images/icon.png
+
+DESTINATION_DIR=/home/$(whoami)/.local/share/applications
+DESKTOP_FILE=$DESTINATION_DIR/popcorn-time.desktop
+
+echo "[Desktop Entry]" > $DESKTOP_FILE
+echo "Version=1.0" >> $DESKTOP_FILE
+echo "Type=Application" >> $DESKTOP_FILE
+echo "Name=$NAME" >> $DESKTOP_FILE
+echo "Icon=$ICON_PATH" >> $DESKTOP_FILE
+echo "Exec=\"$EXECUTABLE\"" >> $DESKTOP_FILE
+echo "Comment=$COMMENT" >> $DESKTOP_FILE
+echo "Categories=Multimedia;" >> $DESKTOP_FILE
+echo "Terminal=false" >> $DESKTOP_FILE
+
+# Updates the desktop entries
+gtk-update-icon-cache /usr/share/icons/hicolor
+
+echo "Desktop entry added for $(whoami)"

--- a/Create-Desktop-Entry
+++ b/Create-Desktop-Entry
@@ -1,28 +1,40 @@
-#!/bin/sh
+#!/bin/bash
 
 # Adds a desktop entry for the current user
 
-NAME="Popcorn Time"
-COMMENT="Watch Movies and TV Shows instantly!"
+create_desktop_entry() {
+	NAME="Popcorn Time"
+	COMMENT="Watch Movies and TV Shows instantly!"
 
-CURRENT_DIR=$(pwd)
-EXECUTABLE=$CURRENT_DIR/Popcorn-Time
-ICON_PATH=$CURRENT_DIR/src/app/images/icon.png
+	CURRENT_DIR=$(pwd)
+	EXECUTABLE=$CURRENT_DIR/Popcorn-Time
+	ICON_PATH=$CURRENT_DIR/src/app/images/icon.png
 
-DESTINATION_DIR=/home/$(whoami)/.local/share/applications
-DESKTOP_FILE=$DESTINATION_DIR/popcorn-time.desktop
+	DESTINATION_DIR=/home/$(whoami)/.local/share/applications
+	DESKTOP_FILE=$DESTINATION_DIR/popcorn-time.desktop
 
-echo "[Desktop Entry]" > $DESKTOP_FILE
-echo "Version=1.0" >> $DESKTOP_FILE
-echo "Type=Application" >> $DESKTOP_FILE
-echo "Name=$NAME" >> $DESKTOP_FILE
-echo "Icon=$ICON_PATH" >> $DESKTOP_FILE
-echo "Exec=\"$EXECUTABLE\"" >> $DESKTOP_FILE
-echo "Comment=$COMMENT" >> $DESKTOP_FILE
-echo "Categories=Multimedia;" >> $DESKTOP_FILE
-echo "Terminal=false" >> $DESKTOP_FILE
+	echo "[Desktop Entry]" > $DESKTOP_FILE
+	echo "Version=1.0" >> $DESKTOP_FILE
+	echo "Type=Application" >> $DESKTOP_FILE
+	echo "Name=$NAME" >> $DESKTOP_FILE
+	echo "Icon=$ICON_PATH" >> $DESKTOP_FILE
+	echo "Exec=\"$EXECUTABLE\"" >> $DESKTOP_FILE
+	echo "Comment=$COMMENT" >> $DESKTOP_FILE
+	echo "Categories=Multimedia;" >> $DESKTOP_FILE
+	echo "Terminal=false" >> $DESKTOP_FILE
 
-# Updates the desktop entries
-gtk-update-icon-cache /usr/share/icons/hicolor
+	# Updates the desktop entries
+	gtk-update-icon-cache /usr/share/icons/hicolor
 
-echo "Desktop entry added for $(whoami)"
+	echo "Desktop entry added for $(whoami)"
+}
+
+printf "Create a desktop entry for Popcorn Time for the current user ? (Y)es/(N)o: "
+read input
+
+if [ "$input" == "Y" ] || [ "$input" == "y" ]
+then
+	create_desktop_entry
+else
+	echo "Just execute ./Create-Desktop-Entry when you are ready to create a desktop entry for Popcorn Time"
+fi

--- a/make_popcorn.sh
+++ b/make_popcorn.sh
@@ -188,6 +188,7 @@ fi
 if grunt build; then
     echo "Popcorn Time built successfully!"
     ./Create-Desktop-Entry
+    echo "Run 'grunt start' from inside the repository to launch the app"
     echo "Enjoy!"
 else
     echo "Popcorn Time encountered an error and couldn't be built"

--- a/make_popcorn.sh
+++ b/make_popcorn.sh
@@ -187,7 +187,7 @@ fi
 
 if grunt build; then
     echo "Popcorn Time built successfully!"
-    echo "Run 'grunt start' from inside the repository to launch the app"
+    ./Create-Desktop-Entry
     echo "Enjoy!"
 else
     echo "Popcorn Time encountered an error and couldn't be built"


### PR DESCRIPTION
I created a script that ask the user if he wants to create a desktop entry for popcorn-time when the app is successfully built. If the user says yes a desktop entry (popcorn-time.desktop) will be added to his/her menu. If the user says no he/she will still be able to create a desktop entry by calling the script (`./Create-Desktop-Entry`) later
