### PR TITLE
use prestart script to install packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,8 +24,7 @@ The [master](https://github.com/popcorn-official/popcorn-desktop) branch which c
 
 #### Quickstart:
 
-1. `npm install`
-2. `npm start`
+1. `npm start`
 
 If you encounter trouble with the above method, you can try:
 

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   "version": "0.3.9",
   "releaseName": "There's nothing on TV",
   "scripts": {
+    "prestart": "npm install",
     "postinstall": "node_modules/.bin/bower install --config.interactive=false && grunt setup",
     "postupdate": "node_modules/.bin/bower update --config.interactive=false && grunt setup",
     "test": "grunt --verbose",


### PR DESCRIPTION
This makes it so that you do not need to run npm install, all you do is run npm start! :smile_cat: 
