### PR TITLE
Fixed image selection for bookmarked movies

### DIFF
--- a/src/app/lib/views/browser/item.js
+++ b/src/app/lib/views/browser/item.js
@@ -131,7 +131,7 @@
                         break;
                     }
                 }
-                coverUrl = this.model.get('image');
+                coverUrl = getBestImage(this.model);
                 this.ui.bookmarkIcon.addClass('selected');
                 break;
             case 'bookmarkedshow':


### PR DESCRIPTION
Covers for bookmarked movies were not showing as mentioned on this issue: https://github.com/popcorn-official/popcorn-desktop/issues/109
