### PR TITLE
Show PopcornTime in 'Select Application' popup

### DIFF
--- a/Create-Desktop-Entry
+++ b/Create-Desktop-Entry
@@ -18,7 +18,7 @@ create_desktop_entry() {
 	echo "Type=Application" >> $DESKTOP_FILE
 	echo "Name=$NAME" >> $DESKTOP_FILE
 	echo "Icon=$ICON_PATH" >> $DESKTOP_FILE
-	echo "Exec=\"$EXECUTABLE\"" >> $DESKTOP_FILE
+	echo "Exec=\"$EXECUTABLE\" -- %u" >> $DESKTOP_FILE
 	echo "Comment=$COMMENT" >> $DESKTOP_FILE
 	echo "Categories=Multimedia;" >> $DESKTOP_FILE
 	echo "Terminal=false" >> $DESKTOP_FILE


### PR DESCRIPTION
Adding `%u` as a param to `Exec` allows PopcornTime to show up in Select Application popup.
Tested on Fedora 23 with Gnome.

```
%u -    A single URL. Local files may either be passed as file: URLs or as file path. 
```
