### PR TITLE
Fixed TVST not restoring token (#113)

### DIFF
--- a/src/app/database.js
+++ b/src/app/database.js
@@ -423,7 +423,10 @@ var Database = {
             })
             .then(function () {
                 App.Trakt = App.Config.getProviderForType('metadata');
+
                 App.TVShowTime = App.Config.getProviderForType('tvst');
+                App.TVShowTime.restoreToken();
+
                 // check update
                 var updater = new App.Updater();
 

--- a/src/app/lib/providers/tvshowtime.js
+++ b/src/app/lib/providers/tvshowtime.js
@@ -7,9 +7,20 @@
         API_CLIENT_SECRET = 'ghmK6ueMJjQLHBwsaao1tw3HUF7JVp_GQTwDwhCn';
 
     function TVShowTime() {
-        App.Providers.CacheProviderV2.call(this, 'metadata');
+        App.Providers.CacheProviderV2.call(this, 'tvst');
+        this.restoreToken();
+    }
+    // Inherit the Cache Provider
+    inherits(TVShowTime, App.Providers.CacheProviderV2);
 
+    TVShowTime.prototype.config = {
+        name: 'TVShowTime'
+    };
+
+    // Try to restore token from settings and auth to tvst api
+    TVShowTime.prototype.restoreToken = function () {
         var tvstAccessToken = AdvSettings.get('tvstAccessToken');
+
         if (tvstAccessToken !== '') {
             this.authenticated = true;
             App.vent.trigger('system:tvstAuthenticated');
@@ -23,12 +34,6 @@
                 token: ''
             };
         }
-    }
-    // Inherit the Cache Provider
-    inherits(TVShowTime, App.Providers.CacheProviderV2);
-
-    TVShowTime.prototype.config = {
-        name: 'TVShowTime'
     };
 
     TVShowTime.prototype.post = function (endpoint, postVariables) {


### PR DESCRIPTION
Moved logic from TVShowTime constructor to another method, which now can be calld from its constructor and Database (after loading settings)
Add new method call on database file to restore token from settings.
