### PR TITLE
Fix scroll bar on chromecast

### DIFF
--- a/src/app/lib/device/chromecast.js
+++ b/src/app/lib/device/chromecast.js
@@ -32,7 +32,7 @@
 
             if (subtitle) {
                 media = {
-                    title: streamModel.get('title'),
+                    title: streamModel.get('title').substr(0, 32) + '...',
                     images: streamModel.get('cover'),
                     subtitles: ['http:' + url.split(':')[1] + ':9999/subtitle.vtt'],
 


### PR DESCRIPTION
When the title of streaming is too long appears this scroll bar:

![](http://imgur.com/LC10SzP.jpg)
![](http://i.imgur.com/LUF7aII.jpg)

With the fix:

![](http://i.imgur.com/cqvMhxW.jpg)
