### PR TITLE
Updated README commands as they referred to the old gulp task

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,8 +32,8 @@ If you encounter trouble with the above method, you can try:
 
 2. `npm install`
 3. `bower install`
-4. `gulp css`
-5. `gulp nwjs`
+4. `gulp build`
+5. `gulp run`
 
 Optionally, you may simply run `./make_popcorn.sh` if you are on a linux or mac based operating system.
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ If you encounter trouble with the above method, you can try:
 2. `npm install`
 3. `bower install`
 4. `gulp css`
-5. `gulp nw:run`
+5. `gulp nwjs`
 
 Optionally, you may simply run `./make_popcorn.sh` if you are on a linux or mac based operating system.
 


### PR DESCRIPTION
Changes proposed in this pull request:

the readme file contained wrong instructions for building: 'gulp nw:run' task is not found in gulpfile.js. Instead run 'gulp nwjs' for building the app.