### PR TITLE
Add --harmony flag to gulp commands for ES6

### DIFF
--- a/make_popcorn.sh
+++ b/make_popcorn.sh
@@ -196,10 +196,10 @@ if [ "$rd_dep" = "yes" ]; then
     echo "Successfully setup for Popcorn Time"
 fi
 
-if gulp build; then
+if gulp --harmony build; then
     echo "Popcorn Time built successfully!"
     ./Create-Desktop-Entry
-    echo "Run 'gulp run' from inside the repository to launch the app"
+    echo "Run 'gulp --harmony run' from inside the repository to launch the app"
     echo "Enjoy!"
 else
     echo "Popcorn Time encountered an error and couldn't be built"


### PR DESCRIPTION
https://github.com/popcorn-official/popcorn-desktop/issues/408

Running the ./make_popcorn.sh script was causing node to raise
issues with the use of const when `gulp build` was run. node v0.10
and v0.12 does not support ES6 by default.

This commit adds the flag to the script so that the script can run
flawlessly.