### PR TITLE
Fix issue #439 about errors to display movies covers from amazon domain

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -3,7 +3,7 @@
 /********
  * setup *
  ********/
-const nwVersion = '0.18.6',
+const nwVersion = '0.18.8',
     availablePlatforms = ['linux32', 'linux64', 'win32', 'win64', 'osx64'],
     releasesDir = 'build',
     nwFlavor = 'sdk';


### PR DESCRIPTION
fix #439 by using the nwjs 0.18.8 availlable here: https://get.popcorntime.sh/repo/nw/v0.18.8/