### PR TITLE
Fix not working options to disable Indie/anime tab

### DIFF
--- a/src/app/lib/views/settings_container.js
+++ b/src/app/lib/views/settings_container.js
@@ -242,6 +242,8 @@
             case 'opensubtitlesAutoUpload':
             case 'subtitles_bold':
             case 'rememberFilters':
+            case 'animeTabDisable':
+            case 'indieTabDisable':
                 value = field.is(':checked');
                 break;
             case 'httpApiUsername':
@@ -341,6 +343,24 @@
                 } else {
                     $('#torrent_col').css('display', 'none');
                     App.vent.trigger('torrentCollection:close');
+                }
+                break;
+            case 'animeTabDisable':
+                if ($('.animeTabShow').css('display') === 'none') {
+                    $('.animeTabShow').css('display', 'block');
+                } else {
+                    $('.animeTabShow').css('display', 'none');
+                    App.vent.trigger('movies:list');
+                    App.vent.trigger('settings:show');
+                }
+                break;
+            case 'indieTabDisable':
+                if ($('.indieTabShow').css('display') === 'none') {
+                    $('.indieTabShow').css('display', 'block');
+                } else {
+                    $('.indieTabShow').css('display', 'none');
+                    App.vent.trigger('movies:list');
+                    App.vent.trigger('settings:show');
                 }
                 break;
             case 'activateRandomize':


### PR DESCRIPTION
Fix issue #401. Users can now select option to disable Indie or Anime tab.
Option value is saved and tab is hidden/visible according to this value.

It do the job for me, but tell me if I missed some aspects.
Thx