### PR TITLE
Increase maxBuffer size for parseReqDeps

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -64,7 +64,7 @@ const parsePlatforms = () => {
 // returns an array of paths with the node_modules to include in builds
 const parseReqDeps = () => {
     return new Promise((resolve, reject) => {
-        exec('npm ls --production=true --parseable=true', (error, stdout, stderr) => {
+        exec('npm ls --production=true --parseable=true', {maxBuffer: 1024 * 500}, (error, stdout, stderr) => {
             if (error || stderr) {
                 reject(error || stderr);
             } else {


### PR DESCRIPTION
'npm ls' stdout can execeed max buffer size of 200KB.
Setting child process max buffer size to 500KB.

Fixes: https://github.com/popcorn-official/popcorn-desktop/issues/468