### PR TITLE
Remove mouseScroll event listener

### DIFF
--- a/src/app/lib/views/player/player.js
+++ b/src/app/lib/views/player/player.js
@@ -39,6 +39,8 @@
             this.remaining = false;
             this.createdRemaining = false;
             this.firstPlay = true;
+
+            this.boundedMouseScroll = this.mouseScroll.bind(this);
         },
 
         isMovie: function () {
@@ -769,7 +771,7 @@
                 }
             });
 
-            document.addEventListener('mousewheel', this.mouseScroll.bind(this));
+            document.addEventListener('mousewheel', this.boundedMouseScroll);
         },
 
         unbindKeyboardShortcuts: function () {
@@ -840,7 +842,7 @@
             // Change when mousetrap can be extended
             $('body').unbind('keydown');
 
-            document.removeEventListener('mousewheel', this.mouseScroll);
+            document.removeEventListener('mousewheel', this.boundedMouseScroll);
         },
 
         toggleMouseDebug: function () {


### PR DESCRIPTION
`.bind()` returns a new function which is not referenced
when trying to removed later. Saving bounded function as a property
to be referenced.

Fixes: https://github.com/popcorn-official/popcorn-desktop/issues/471