### PR TITLE
Internationalise keybindings

### DIFF
--- a/src/app/app.js
+++ b/src/app/app.js
@@ -296,11 +296,11 @@ Mousetrap.bind('shift+up shift+up shift+down shift+down shift+left shift+right s
     } else {
         body.addClass('knm');
     }
-});
+}, 'keydown');
 Mousetrap.bindGlobal(['command+ctrl+f', 'ctrl+alt+f'], function (e) {
     e.preventDefault();
     win.toggleFullscreen();
-});
+}, 'keydown');
 Mousetrap.bind('shift+b', function (e) {
     if (!ScreenResolution.SD) {
         if (App.settings.bigPicture) {
@@ -322,7 +322,7 @@ Mousetrap.bind('shift+b', function (e) {
             autoclose: true
         }));
     }
-});
+}, 'keydown');
 
 // Drag n' Drop Torrent Onto PT Window to start playing (ALPHA)
 window.ondragenter = function (e) {

--- a/src/app/lib/views/browser/list.js
+++ b/src/app/lib/views/browser/list.js
@@ -137,17 +137,17 @@
 
             Mousetrap.bind('right', _this.moveRight);
 
-            Mousetrap.bind('f', _this.toggleSelectedFavourite);
+            Mousetrap.bind('f', _this.toggleSelectedFavourite, 'keydown');
 
-            Mousetrap.bind('w', _this.toggleSelectedWatched);
+            Mousetrap.bind('w', _this.toggleSelectedWatched, 'keydown');
 
             Mousetrap.bind(['enter', 'space'], _this.selectItem);
 
-            Mousetrap.bind(['ctrl+f', 'command+f'], _this.focusSearch);
+            Mousetrap.bind(['ctrl+f', 'command+f'], _this.focusSearch, 'keydown');
 
             Mousetrap(document.querySelector('input')).bind(['ctrl+f', 'command+f', 'esc'], function (e, combo) {
                 $('.search input').blur();
-            });
+            }, 'keydown');
 
             Mousetrap.bind(['tab', 'shift+tab'], function (e, combo) {
                 if ((App.PlayerView === undefined || App.PlayerView.isDestroyed) && $('#about-container').children().length <= 0 && $('#player').children().length <= 0) {
@@ -207,13 +207,13 @@
                 if ((App.PlayerView === undefined || App.PlayerView.isDestroyed) && $('#about-container').children().length <= 0 && $('#player').children().length <= 0) {
                     $('.favorites').click();
                 }
-            });
+            }, 'keydown');
 
             Mousetrap.bind('i', function () {
                 if ((App.PlayerView === undefined || App.PlayerView.isDestroyed) && $('#player').children().length <= 0) {
                     $('.about').click();
                 }
-            });
+            }, 'keydown');
 
         },
 

--- a/src/app/lib/views/movie_detail.js
+++ b/src/app/lib/views/movie_detail.js
@@ -172,10 +172,10 @@
             Mousetrap.bind(['enter', 'space'], function (e) {
                 $('#watch-now').click();
             });
-            Mousetrap.bind('q', this.toggleQuality);
+            Mousetrap.bind('q', this.toggleQuality, 'keydown');
             Mousetrap.bind('f', function () {
                 $('.favourites-toggle').click();
-            });
+            }, 'keydown');
         },
 
         unbindKeyboardShortcuts: function () { // There should be a better way to do this

--- a/src/app/lib/views/player/player.js
+++ b/src/app/lib/views/player/player.js
@@ -629,35 +629,35 @@
 
             Mousetrap.bind(['f', 'F'], function (e) {
                 that.toggleFullscreen();
-            });
+            }, 'keydown');
 
             Mousetrap.bind('h', function (e) {
                 that.adjustSubtitleOffset(-0.1);
-            });
+            }, 'keydown');
 
             Mousetrap.bind('g', function (e) {
                 that.adjustSubtitleOffset(0.1);
-            });
+            }, 'keydown');
 
             Mousetrap.bind('shift+h', function (e) {
                 that.adjustSubtitleOffset(-1);
-            });
+            }, 'keydown');
 
             Mousetrap.bind('shift+g', function (e) {
                 that.adjustSubtitleOffset(1);
-            });
+            }, 'keydown');
 
             Mousetrap.bind('ctrl+h', function (e) {
                 that.adjustSubtitleOffset(-5);
-            });
+            }, 'keydown');
 
             Mousetrap.bind('ctrl+g', function (e) {
                 that.adjustSubtitleOffset(5);
-            });
+            }, 'keydown');
 
             Mousetrap.bind(['space', 'p'], function (e) {
                 $('.vjs-play-control').click();
-            });
+            }, 'keydown');
 
             Mousetrap.bind('right', function (e) {
                 that.seek(5);
@@ -709,39 +709,39 @@
 
             Mousetrap.bind(['m', 'M'], function (e) {
                 that.toggleMute();
-            });
+            }, 'keydown');
 
             Mousetrap.bind(['u', 'U'], function (e) {
                 that.displayStreamURL();
-            });
+            }, 'keydown');
 
             Mousetrap.bind('j', function (e) {
                 that.adjustPlaybackRate(-0.1, true);
-            });
+            }, 'keydown');
 
             Mousetrap.bind(['k', 'shift+k', 'ctrl+k'], function (e) {
                 that.adjustPlaybackRate(1.0, false);
-            });
+            }, 'keydown');
 
             Mousetrap.bind(['l'], function (e) {
                 that.adjustPlaybackRate(0.1, true);
-            });
+            }, 'keydown');
 
             Mousetrap.bind(['shift+j', 'ctrl+j'], function (e) {
                 that.adjustPlaybackRate(0.5, false);
-            });
+            }, 'keydown');
 
             Mousetrap.bind('shift+l', function (e) {
                 that.adjustPlaybackRate(2.0, false);
-            });
+            }, 'keydown');
 
             Mousetrap.bind('ctrl+l', function (e) {
                 that.adjustPlaybackRate(4.0, false);
-            });
+            }, 'keydown');
 
             Mousetrap.bind('ctrl+d', function (e) {
                 that.toggleMouseDebug();
-            });
+            }, 'keydown');
 
             Mousetrap.bind('0', function (e) {
                 that.scaleWindow(0.5);

--- a/src/app/lib/views/show_detail.js
+++ b/src/app/lib/views/show_detail.js
@@ -112,17 +112,17 @@
             }
         },
         initKeyboardShortcuts: function () {
-            Mousetrap.bind('q', _this.toggleQuality);
+            Mousetrap.bind('q', _this.toggleQuality, 'keydown');
             Mousetrap.bind('down', _this.nextEpisode);
             Mousetrap.bind('up', _this.previousEpisode);
-            Mousetrap.bind('w', _this.toggleEpisodeWatched);
+            Mousetrap.bind('w', _this.toggleEpisodeWatched, 'keydown');
             Mousetrap.bind(['enter', 'space'], _this.playEpisode);
             Mousetrap.bind(['esc', 'backspace'], _this.closeDetails);
             Mousetrap.bind(['ctrl+up', 'command+up'], _this.previousSeason);
             Mousetrap.bind(['ctrl+down', 'command+down'], _this.nextSeason);
             Mousetrap.bind('f', function () {
                 $('.sha-bookmark').click();
-            });
+            }, 'keydown');
         },
 
         unbindKeyboardShortcuts: Mousetrap.reset,


### PR DESCRIPTION
You can not use keybindings while in non-latin keyboard layout. Tested this on fresh build of development branch.

Popcorn uses [Mousetrap](https://craig.is/killing/mice) for keybindings. We need to listen to `keydown` event in order to bind to keyboard key press, not character input.

This PR adds `keydown` argument to `Mousetrap.bind` calls, where it's appropriate.