### PR TITLE
anime covers dirty fix

### DIFF
--- a/src/app/lib/views/browser/item.js
+++ b/src/app/lib/views/browser/item.js
@@ -39,7 +39,7 @@
                 watched, cached, that = this;
 
             // dirty fix for missing anime covers from hummingbird.me - remove when animeApi return valid cover urls
-            if (img.indexOf('static.hummingbird.me/anime/poster_images') !== -1) { img='https://media.kitsu.io/anime/poster_images/' + imdb + '/small.jpg'; }
+            if (img !== undefined && img.indexOf('static.hummingbird.me/anime/poster_images') !== -1) { img='https://media.kitsu.io/anime/poster_images/' + imdb + '/small.jpg'; }
 
             switch (itemtype) {
             case 'bookmarkedshow':

--- a/src/app/lib/views/browser/item.js
+++ b/src/app/lib/views/browser/item.js
@@ -38,6 +38,9 @@
                 img = (images && typeof images.poster !== 'object') ? images.poster : this.model.get('image'),
                 watched, cached, that = this;
 
+            // dirty fix for missing anime covers from hummingbird.me - remove when animeApi return valid cover urls
+            if (img.indexOf('static.hummingbird.me/anime/poster_images') !== -1) { img='https://media.kitsu.io/anime/poster_images/' + imdb + '/small.jpg'; }
+
             switch (itemtype) {
             case 'bookmarkedshow':
                 watched = App.watchedShows.indexOf(imdb) !== -1;
@@ -240,6 +243,10 @@
                     .then(function (data) {
                         //console.log(data, Type);
                         data.provider = provider.name;
+
+                         // dirty fix for missing anime covers from hummingbird.me - remove when animeApi return valid cover urls
+                        if (data.images.poster.indexOf('static.hummingbird.me/anime/poster_images') !== -1) { data.images.banner=data.images.fanart=data.images.poster='https://media.kitsu.io/anime/poster_images/' + data.imdb_id + '/small.jpg'; }
+
                         $('.spinner').hide();
                         App.vent.trigger(type + ':showDetail', new App.Model[Type](data));
                     }).catch(function (err) {

--- a/src/app/lib/views/browser/item.js
+++ b/src/app/lib/views/browser/item.js
@@ -245,7 +245,9 @@
                         data.provider = provider.name;
 
                          // dirty fix for missing anime covers from hummingbird.me - remove when animeApi return valid cover urls
-                        if (data.images.poster.indexOf('static.hummingbird.me/anime/poster_images') !== -1) { data.images.banner=data.images.fanart=data.images.poster='https://media.kitsu.io/anime/poster_images/' + data.imdb_id + '/small.jpg'; }
+                        if (data.images !== undefined && data.images.poster !== undefined && data.images.poster.indexOf('static.hummingbird.me/anime/poster_images') !== -1) {
+                            data.images.banner=data.images.fanart=data.images.poster='https://media.kitsu.io/anime/poster_images/' + data.imdb_id + '/small.jpg';
+                        }
 
                         $('.spinner').hide();
                         App.vent.trigger(type + ':showDetail', new App.Model[Type](data));


### PR DESCRIPTION
Since "static.hummingbird.me" is not sending anime covers this is dirty fix redirecting cover url requests to "kitsu.io"

Issue #573 
