### PR TITLE
instanceof String and some double calls in item.js

### DIFF
--- a/src/app/lib/views/browser/item.js
+++ b/src/app/lib/views/browser/item.js
@@ -262,15 +262,10 @@
                 if (Settings.watchedCovers === 'fade') {
                     this.$el.removeClass('watched');
                 }
-                Database.markMovieAsNotWatched({
-                        imdb_id: this.model.get('imdb_id')
-                    }, true)
-                    .then(function () {
-                        that.model.set('watched', false);
-                        App.vent.trigger('movie:unwatched', {
-                            imdb_id: that.model.get('imdb_id')
-                        }, 'seen');
-                    });
+                that.model.set('watched', false);
+                App.vent.trigger('movie:unwatched', {
+                    imdb_id: that.model.get('imdb_id')
+                }, 'seen');
             } else {
                 this.ui.watchedIcon.addClass('selected');
                 switch (Settings.watchedCovers) {
@@ -281,23 +276,17 @@
                     this.$el.remove();
                     break;
                 }
-                Database.markMovieAsWatched({
-                        imdb_id: this.model.get('imdb_id'),
-                        from_browser: true
-                    }, true)
-                    .then(function () {
-                        that.model.set('watched', true);
-                        App.vent.trigger('movie:watched', {
-                            imdb_id: that.model.get('imdb_id')
-                        }, 'seen');
-                    });
-
+                that.model.set('watched', true);
+                App.vent.trigger('movie:watched', {
+                    imdb_id: that.model.get('imdb_id')
+                }, 'seen');
             }
 
             this.ui.watchedIcon.tooltip({
                 title: this.ui.watchedIcon.hasClass('selected') ? i18n.__('Mark as unseen') : i18n.__('Mark as Seen')
             });
         },
+
 
         toggleFavorite: function (e) {
             e.stopPropagation();
@@ -312,7 +301,6 @@
                 Database.deleteBookmark(this.model.get('imdb_id'))
                     .then(function () {
                         win.info('Bookmark deleted (' + that.model.get('imdb_id') + ')');
-                        App.userBookmarks.splice(App.userBookmarks.indexOf(that.model.get('imdb_id')), 1);
                     })
                     .then(function () {
                         return Database.deleteMovie(that.model.get('imdb_id'));
@@ -383,7 +371,6 @@
                                     .then(function () {
                                         win.info('Bookmark added (' + that.model.get('imdb_id') + ')');
                                         that.model.set('bookmarked', true);
-                                        App.userBookmarks.push(that.model.get('imdb_id'));
                                     });
                             });
                     } else {
@@ -412,7 +399,6 @@
                             })
                             .then(function () {
                                 win.info('Bookmark added (' + that.model.get('imdb_id') + ')');
-                                App.userBookmarks.push(that.model.get('imdb_id'));
                                 that.model.set('bookmarked', true);
                             });
                     }
@@ -425,8 +411,6 @@
                     Database.deleteBookmark(this.model.get('imdb_id'))
                         .then(function () {
                             win.info('Bookmark deleted (' + that.model.get('imdb_id') + ')');
-
-                            App.userBookmarks.splice(App.userBookmarks.indexOf(that.model.get('imdb_id')), 1);
 
                             // we'll make sure we dont have a cached show
                             Database.deleteTVShow(that.model.get('imdb_id'));
@@ -452,7 +436,6 @@
                                     win.info('Bookmark added (' + that.model.get('imdb_id') + ')');
                                     that.ui.bookmarkIcon.addClass('selected');
                                     that.model.set('bookmarked', true);
-                                    App.userBookmarks.push(that.model.get('imdb_id'));
                                 }).catch(function (err) {
                                     win.error('promisifyDb()', err);
                                 });


### PR DESCRIPTION
"instanceof String" never returns true unless var is declared as "new String" so 'typeof' is better solution

also trigger 'movie:watched' is calling Database.markMovieAsWatched so it not necessary to do execute both. same for unwatched

also for Database.addBookmark which is executing App.userBookmarks.push and the same for deleteBookmark doing splice