### PR TITLE
firstUnwatched annoying issue

### DIFF
--- a/src/app/lib/views/show_detail.js
+++ b/src/app/lib/views/show_detail.js
@@ -233,6 +233,13 @@
                         var unseen = episodes.filter(function (item) {
                             return episodesSeen.indexOf(item) === -1;
                         });
+                        // filter unseen to list only current season episodes and above
+                        var lastSeen = episodesSeen[episodesSeen.length - 1];
+                        if (lastSeen>100) {
+                            unseen = unseen.filter(function (item) {
+                                return item>lastSeen;
+                            });
+                        }
                         if (AdvSettings.get('tv_detail_jump_to') !== 'firstUnwatched') {
                             var lastSeen = episodesSeen[episodesSeen.length - 1];
 

--- a/src/app/lib/views/show_detail.js
+++ b/src/app/lib/views/show_detail.js
@@ -241,7 +241,7 @@
                             });
                         }
                         if (AdvSettings.get('tv_detail_jump_to') !== 'firstUnwatched') {
-                            var lastSeen = episodesSeen[episodesSeen.length - 1];
+                            lastSeen = episodesSeen[episodesSeen.length - 1];
 
                             if (lastSeen !== episodes[episodes.length - 1]) {
                                 var idx;

--- a/src/app/lib/views/show_detail.js
+++ b/src/app/lib/views/show_detail.js
@@ -241,8 +241,6 @@
                             });
                         }
                         if (AdvSettings.get('tv_detail_jump_to') !== 'firstUnwatched') {
-                            lastSeen = episodesSeen[episodesSeen.length - 1];
-
                             if (lastSeen !== episodes[episodes.length - 1]) {
                                 var idx;
                                 _.find(episodes, function (data, dataIdx) {


### PR DESCRIPTION
'firstUnwatched' is giving back first unseen episode no matter what season is currently viewed.

So if couple of previous seasons or episodes from the current season are not marked as watched code will return first unseen episode of all seasons which is annoying for people (me +1) that have watched previous episodes somewhere else.

To repeat this issue choose any unseen show, select season 2 or later and mark any episode as 'seen' (it works for season 1 too but naturally you won't notice this issue if you click on episode 1 in season 1 and then keep clicking one by one episode as they are displayed).