### PR TITLE
multiple subtitles per language

### DIFF
--- a/src/app/lib/providers/opensubtitles.js
+++ b/src/app/lib/providers/opensubtitles.js
@@ -18,11 +18,6 @@
         name: 'OpenSubtitles'
     };
 
-    OpenSubtitles.prototype.constructor = OpenSubtitles;
-    OpenSubtitles.prototype.config = {
-        name: 'OpenSubtitles'
-    };
-
     var normalizeLangCodes = function (data) {
         Object.keys(data).forEach(function(key,index) {
             // iterating required because of possible multiple subs per language format

--- a/src/app/lib/providers/opensubtitles.js
+++ b/src/app/lib/providers/opensubtitles.js
@@ -18,15 +18,47 @@
         name: 'OpenSubtitles'
     };
 
+    OpenSubtitles.prototype.constructor = OpenSubtitles;
+    OpenSubtitles.prototype.config = {
+        name: 'OpenSubtitles'
+    };
+
     var normalizeLangCodes = function (data) {
-        if ('pb' in data) {
-            data['pt-br'] = data['pb'];
-            delete data['pb'];
-        }
+        Object.keys(data).forEach(function(key,index) {
+            // iterating required because of possible multiple subs per language format
+            if (key === 'pb' || key.indexOf('pb|') === 0) {
+                data[key] = data[ key.replace('pb','pt-br') ];
+                delete data[key];
+            }
+        });
         return data;
     };
 
-    var formatForButter = function (data) {
+    var formatForButter = function (data_obj) {
+        var data = {};
+        var multi_id = 0;
+        var multi_langcode = '';
+        var multi_urls = {};
+
+        // formating subtitle object data to pre-multiple subtitle format
+        for (const[langcode,value] of Object.entries(data_obj)) {
+            multi_id=1;
+            multi_urls = {};
+            value.forEach(function(subtitle) {
+                // filtering out already existing urls
+                if ( !(subtitle.url in multi_urls) ) {
+                    multi_langcode = langcode;
+                    if (multi_id > 1) {
+                        // first subtitle without multi-subtitle format because of defaultSubtitle from settings
+                        multi_langcode += '|' + multi_id.toString();
+                    }
+                    data[multi_langcode] = subtitle;
+                    multi_urls[subtitle.url] = '';
+                    multi_id++;
+                }
+            });
+        }
+
         data = normalizeLangCodes(data);
         for (var lang in data) {
             data[lang] = data[lang].url;
@@ -36,6 +68,8 @@
 
     OpenSubtitles.prototype.fetch = function (queryParams) {
         queryParams.extensions = ['srt'];
+        // this will return all available subtitles, not just 1 per language
+        queryParams.limit='all';
         return openSRT.search(queryParams)
             .then(formatForButter);
     };

--- a/src/app/lib/subtitle/generic.js
+++ b/src/app/lib/subtitle/generic.js
@@ -177,7 +177,7 @@
                 callback(dataBuff.toString('utf8'));
                 // We do
             } else {
-                var langInfo = App.Localization.langcodes[language] || {};
+                var langInfo = App.Localization.langcodes[ (language.indexOf('|')>0 ? language.substr(0,language.indexOf('|')) : language) ] || {};
                 win.debug('SUB charset expected for \'%s\': ', language, langInfo.encoding);
                 if (langInfo.encoding !== undefined && langInfo.encoding.indexOf(detectedEncoding) < 0) {
                     // The detected encoding was unexepected to the language, so we'll use the most common

--- a/src/app/templates/player.tpl
+++ b/src/app/templates/player.tpl
@@ -57,15 +57,27 @@
 </div>
 <%
     var subArray = [];
+    var multi_id = "";
+    var langcode2 = "";
+
     for (var langcode in subtitle) {
+        if (langcode.indexOf('|')>0) {
+            multi_id = langcode.substr(langcode.indexOf('|')+1,99);
+            langcode2 = langcode.substr(0,langcode.indexOf('|'));
+        } else {
+            multi_id = "1";
+            langcode2 = langcode;
+        }
+
         subArray.push({
             "language": langcode,
-            "languageName": (App.Localization.langcodes[langcode] !== undefined ? App.Localization.langcodes[langcode].nativeName : langcode),
+            "languageName": (App.Localization.langcodes[langcode2] !== undefined ? App.Localization.langcodes[langcode2].nativeName : langcode) + '... ' + multi_id,
+            "multi_id": multi_id,
             "sub": subtitle[langcode]
         });
     }
     subArray.sort(function (sub1, sub2) {
-        return sub1.languageName.localeCompare(sub2.languageName);
+        return sub1.languageName.localeCompare(sub2.languageName, undefined, {numeric: true, sensitivity: 'base'});
     });
 
     var subtracks = "";
@@ -80,7 +92,7 @@
         if(defaultSub == subArray[index].language)
             imDefault = "default";
 
-        subtracks += '<track kind="subtitles" src="' + subArray[index].sub + '" srclang="'+ subArray[index].language +'" label="' + subArray[index].languageName + '" charset="utf-8" '+ imDefault +' />';
+        subtracks += '<track kind="subtitles" src="' + subArray[index].sub + '" srclang="'+ subArray[index].language +'" label="' + (subArray[index].multi_id == '1' ? subArray[index].languageName.substr(0,subArray[index].languageName.indexOf('...')) : subArray[index].languageName.substr(subArray[index].languageName.indexOf('...'),99) ) + '" charset="utf-8" '+ imDefault +' />';
     }
 %>
 <video id="video_player" width="100%" height="100%" class="video-js vjs-popcorn-skin" controls preload="auto" autoplay >

--- a/src/app/vendor/videojshooks.js
+++ b/src/app/vendor/videojshooks.js
@@ -301,7 +301,7 @@ vjs.TextTrack.prototype.load = function () {
                     language = Settings.subtitle_language;
                     console.log('SUB charset: using subtitles_language setting (' + language + ') as default');
                 }
-                var langInfo = App.Localization.langcodes[language] || {};
+                var langInfo = App.Localization.langcodes[ (language.indexOf('|')>0 ? language.substr(0,language.indexOf('|')) : language) ] || {};
                 console.log('SUB charset expected:', langInfo.encoding);
                 if (langInfo.encoding !== undefined && langInfo.encoding.indexOf(detectedEncoding) < 0) {
                     // The detected encoding was unexepected to the language, so we'll use the most common


### PR DESCRIPTION
current code is showing just one subtitle per language. but since some subtitles as completely wrong (from different title) and since opensubtitle can send multiple subtitles per each language I have written this code change proposal to support multiple subtitles per language.

those multiple sources will be listed in subtitle frame as:

Language-A
..... 2
..... 3
Language-B
Language-C
..... 2
..... 3
..... 4


in subtitle array (above example) will be stored as:

langcodeA: 'url..........',
langcodeA|2: 'url...........',
langcodeA|3: 'url...........',
langcodeB: 'url...........',
langcodeC: 'url...........',
langcodeC|2: 'url...........',
langcodeC|3: 'url...........',
langcodeC|4: 'url...........',
