### PR TITLE
Updated opensubtitles-api package to stable release

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "nedb": "1.8.0",
     "node-captions": "0.4.6",
     "node-webkit-fdialogs": "latest",
-    "opensubtitles-api": "4.0.0-rc1",
+    "opensubtitles-api": "4.0.0",
     "os-name": "2.0.1",
     "popcorn-txt-api": "git+https://github.com/hackhackhack/popcorn-txt-api",
     "q": "2.0.3",


### PR DESCRIPTION
We should not rely on release candidates for production software.