### PR TITLE
Important modification for system stability if mounted /tmp to tmpfs

### DIFF
--- a/src/app/settings.js
+++ b/src/app/settings.js
@@ -164,7 +164,7 @@ Settings.opensubtitlesPassword = '';
 // Advanced options
 Settings.connectionLimit = 55;
 Settings.streamPort = 0; // 0 = Random
-Settings.tmpLocation = path.join(os.tmpDir(), Settings.projectName);
+Settings.tmpLocation = path.join(os.homedir(), '/.cache', Settings.projectName);
 Settings.databaseLocation = path.join(data_path, 'data');
 Settings.deleteTmpOnClose = true;
 Settings.automaticUpdating = true;


### PR DESCRIPTION
This fix prevent to PopocornTime fill memory if system use TMPFS on /tmp
Regards