### PR TITLE
Ability to detect VLC binary installed via snap package.

### DIFF
--- a/src/app/lib/device/ext-player.js
+++ b/src/app/lib/device/ext-player.js
@@ -199,6 +199,7 @@
     // linux
     addPath('/usr/bin');
     addPath('/usr/local/bin');
+    addPath('/snap/bin');
     // darwin
     addPath('/Applications');
     addPath(process.env.HOME + '/Applications');


### PR DESCRIPTION
Since VLC 3.0 is available in a snap package version, some users will be
interested to have it detected to use it as an external player.

 * search binaries into /snap/bin
 * Fix #701 