### PR TITLE
Fix viewstack

### DIFF
--- a/src/app/lib/views/main_window.js
+++ b/src/app/lib/views/main_window.js
@@ -42,14 +42,14 @@
             
             _.each(_this.getRegions(), function (element, index) {
 
-                element.on('show', function (view) {
+                element.on('before:show', function (region, view) {
                     if (view.className && App.ViewStack[0] !== view.className) {
                         App.ViewStack.push(view.className);
                     }
                     App.vent.trigger('viewstack:push', view.className);
                 });
 
-                element.on('empty', function (view) {
+                element.on('empty', function (region, view) {
                     var viewName = (typeof view !== 'undefined' ? view.className : 'unknown');
                     App.ViewStack.pop();
                     App.vent.trigger('viewstack:pop', viewName);


### PR DESCRIPTION
Addresses https://github.com/popcorn-official/popcorn-desktop/pull/721#issuecomment-377459811

Definitely a bug in whatever the viewstack is, but I don't think this entirely resolve #725 
When testing the player "p" works fine, but "space" does not for play/pause

I don't think this issue is related to Marionette, but likely Mousetrap because the related code is:
```
            Mousetrap.bind(['space', 'p'], function (e) {
                $('.vjs-play-control').click();
            }, 'keydown');
```

Possibly something is already bound to `space` or something?  I dunno.