### PR TITLE
Set butter-provider-vodo version to 0.3.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "butter-provider-anime": "1.0.0",
     "butter-provider-movies": "1.0.3",
     "butter-provider-tvapi": "git+https://github.com/team-pct/butter-provider-tvapi",
-    "butter-provider-vodo": "git+https://github.com/butterproviders/butter-provider-vodo",
+    "butter-provider-vodo": "0.3.1",
     "butter-settings-popcorntime.io": "git+https://github.com/popcorn-official/butter-settings-popcorn",
     "chromecasts": "1.9.0",
     "defer-request": "0.0.2",


### PR DESCRIPTION
Fixes #770, #741 .

Changes proposed in this pull request:
- Set butter-provider-vodo version to 0.3.1


I've read the [Contributor License Agreement](/CONTRIBUTING.md#contributor-license-agreement)