### PR TITLE
Add local subtitles support to chromecast streams

### DIFF
--- a/src/app/lib/device/chromecast.js
+++ b/src/app/lib/device/chromecast.js
@@ -19,21 +19,76 @@
             this.attributes.id = this._makeID(this.device.name);
             this.attributes.name = this.device.name;
             this.attributes.address = this.device.host;
+            this.updatingSubtitles = false;
         },
 
         play: function (streamModel) {
             var self = this;
+
+            var url = streamModel.get('src');
+            this.attributes.url = url;
+            const media = this.createMedia(streamModel);
+
+            win.info('Chromecast: play ' + url + ' on \'' + this.get('name') + '\'');
+            win.info('Chromecast: connecting to ' + this.device.host);
+
+            self.device.play(url, media, function (err, status) {
+                if (err) {
+                    win.error('chromecast.play error: ', err);
+                } else {
+                    win.info('Playing ' + url + ' on ' + self.get('name'));
+                    self.set('loadedMedia', status.media);
+                }
+            });
+            this.device.on('status', function (status) {
+                // If we got interrupted because we are updating subtitles, we don't want to close the streamer
+                // There's currently no way to reload a media with the castv2 library without interrupting the current media
+                if (status.idleReason === 'INTERRUPTED' && self.updatingSubtitles) {
+                    self.updatingSubtitles = false;
+                } else {
+                    self._internalStatusUpdated(status);
+                }
+            });
+
+            App.vent.on('videojs:drop_sub', function() {
+                self.updatingSubtitles = true;
+                var subname = Settings.droppedSub;
+                var subpath = path.join(App.settings.tmpLocation, subname);
+                win.info('Subtitles dropped on chromecast:', subpath);
+
+                App.vent.trigger('stream:serve_subtitles', subpath);
+
+                self.device.status(function (err, status) {
+                    const media = self.createMedia(streamModel, true);
+
+                    // After updating the subtitles, we come back to where we were before, minus a small buffer to make sure
+                    // we didn't miss anything while switching the subtitles
+                    media.seek = status.currentTime - 5.0;
+
+                    self.device.play(url, media, function (err, status) {
+                        if (err) {
+                            win.error('chromecast.play error: ', err);
+                        } else {
+                            win.info('Playing ' + url + ' on ' + self.get('name'));
+                            self.set('loadedMedia', status.media);
+                        }
+                    });
+                });
+            });
+        },
+
+        createMedia: function(streamModel, useLocalSubtitle) {
             var subtitle = streamModel.get('subFile');
             var cover = streamModel.get('cover');
             var url = streamModel.get('src');
             var attr= streamModel.attributes;
-            this.attributes.url = url;
-            var media;
 
-            if (subtitle) {
+            let media = {};
+
+            if (subtitle || useLocalSubtitle) {
                 media = {
+                    images: cover,
                     title: streamModel.get('title').substring(0,50),
-                    images: streamModel.get('cover'),
                     subtitles: ['http:' + url.split(':')[1] + ':9999/subtitle.vtt'],
 
                     textTrackStyle: {
@@ -56,20 +111,8 @@
                     title: streamModel.get('title').substring(0,50)
                 };
             }
-            win.info('Chromecast: play ' + url + ' on \'' + this.get('name') + '\'');
-            win.info('Chromecast: connecting to ' + this.device.host);
 
-  				self.device.play(url, media, function (err, status) {
-  					if (err) {
-  						win.error('chromecast.play error: ', err);
-  					} else {
-  						win.info('Playing ' + url + ' on ' + self.get('name'));
-  						self.set('loadedMedia', status.media);
-  					}
-  				});
-  this.device.on('status', function (status) {
-                self._internalStatusUpdated(status);
-            });
+            return media;
         },
 
         pause: function () {
@@ -78,6 +121,7 @@
 
         stop: function () {
             win.info('Closing Chromecast Casting');
+            App.vent.off('videojs:drop_sub');
             App.vent.trigger('stream:stop');
             App.vent.trigger('player:close');
             App.vent.trigger('torrentcache:stop');
@@ -87,6 +131,8 @@
                 device.removeAllListeners();
                 win.info('Chromecast: stopped. Listeners removed!');
             });
+
+            App.vent.trigger('stream:unserve_subtitles');
         },
 
         seekPercentage: function (percentage) {

--- a/src/app/lib/streamer.js
+++ b/src/app/lib/streamer.js
@@ -432,6 +432,27 @@
             }
         },
 
+        // serve subtitles on a local server to make them accessible to remote cast devices
+        serveSubtitles: function(localPath) {
+            App.vent.trigger('subtitle:convert', {
+                path: localPath
+            }, function(err, res) {
+                if (err) {
+                    win.error('error converting subtitles', err);
+                    this.streamInfo.set('subFile', null);
+                    App.vent.trigger('notification:show', new App.Model.Notification({
+                        title: i18n.__('Error converting subtitle'),
+                        body: i18n.__('Try another subtitle or drop one in the player'),
+                        showRestart: false,
+                        type: 'error',
+                        autoclose: true
+                    }));
+                } else {
+                    App.Subtitles.Server.start(res);
+                }
+            }.bind(this));
+        },
+
         handleSubtitles: function () {
             if (this.stopped) {
                 return;
@@ -508,5 +529,7 @@
 
     App.vent.on('stream:start', streamer.start.bind(streamer));
     App.vent.on('stream:stop', streamer.stop.bind(streamer));
+    App.vent.on('stream:serve_subtitles', streamer.serveSubtitles.bind(streamer));
+    App.vent.on('stream:unserve_subtitles', App.Subtitles.server.stop);
 
 })(window.App);


### PR DESCRIPTION
Before, only default subtitles embedded in the torrent link could be
played. Now, if the user drags a torrent file on the chromecast player,
we serve the local files to the subtitles server so that the chromecast
can access them like remote subtitles. Right now, only the subtitles
drag-and-dropping works, but the UI will come in a future update.