### PR TITLE
Fix TorrentCollection search sorting

### DIFF
--- a/src/app/lib/views/torrent_collection.js
+++ b/src/app/lib/views/torrent_collection.js
@@ -264,13 +264,7 @@
 
             var sortBySeeds = function (items) {
                 return items.sort(function (a, b) {
-                    if (a.seeds > b.seeds) {
-                        return -1;
-                    }
-                    if (a.seeds < b.seeds) {
-                        return 1;
-                    }
-                    return 0;
+                    return b.seeds - a.seeds;
                 });
             };
 


### PR DESCRIPTION
The sort by seeds wasn't correct, it was sorting result by comparing seeds number like strings instead of integers. So 123 was before 1220 for example.

This fix that.

Credit to /u/yiannis309