### PR TITLE
Detect and use IINA player as external player on MacOS

### DIFF
--- a/src/app/lib/device/ext-player.js
+++ b/src/app/lib/device/ext-player.js
@@ -34,6 +34,12 @@
             subswitch: '-sub ',
             fs: '-fs',
         },
+        'IINA': {
+            type: 'mpv',
+            cmd: '/Contents/MacOS/iina-cli',
+            subswitch: '--mpv-sub-file=',
+            fs: '--mpv-fs',
+        },
         'mplayer': {
             type: 'mplayer',
             cmd: 'mplayer',


### PR DESCRIPTION
using IINA player as external player on MacOS

See https://github.com/lhc70000/iina/issues/1001#issuecomment-362950758 and https://www.reddit.com/r/PopCornTime/comments/8qfe7r/external_players_not_working_on_popcorntime_310/e0jcepw/

was unable to test personaly but merseyV did and validated.

Credits to merseyV for pointing to it and @kjyv for the code.