### PR TITLE
Switched to dlnacasts2

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "butter-settings-popcorntime.io": "git+https://github.com/popcorn-official/butter-settings-popcorn",
     "chromecasts": "1.9.0",
     "defer-request": "0.0.2",
-    "dlnacasts": "0.1.0",
+    "dlnacasts2": "0.1.2",
     "gitlab": "1.4.1",
     "i18n": "0.x.x",
     "iconv-lite": "0.x.x",

--- a/src/app/lib/device/dlna.js
+++ b/src/app/lib/device/dlna.js
@@ -1,6 +1,6 @@
 (function(App) {
     'use strict';
-    var dlnacasts = require('dlnacasts')();
+    var dlnacasts = require('dlnacasts2')();
     var xmlb = require('xmlbuilder');
     var collection = App.Device.Collection;
 


### PR DESCRIPTION
The original dlnacasts is virtually abandoned and included
an issue where its use of ssdp.search() would complete faster
than some clients could respond, resulting in some DLNA devices
not being detected. By using dlncasts2, a timeout is added
which resolves the bug.

Addresses issue #843 