### PR TITLE
Fix options to disable Indie/anime tab

### DIFF
--- a/src/app/lib/views/settings_container.js
+++ b/src/app/lib/views/settings_container.js
@@ -243,6 +243,8 @@
             case 'opensubtitlesAutoUpload':
             case 'subtitles_bold':
             case 'rememberFilters':
+            case 'animeTabDisable':
+            case 'indieTabDisable':
                 value = field.is(':checked');
                 break;
             case 'httpApiUsername':
@@ -344,6 +346,24 @@
                     App.vent.trigger('torrentCollection:close');
                 }
                 break;
+            case 'animeTabDisable':
+                 if ($('.animeTabShow').css('display') === 'none') {
+                    $('.animeTabShow').css('display', 'block');
+                } else {
+                    $('.animeTabShow').css('display', 'none');
+                    App.vent.trigger('movies:list');
+                    App.vent.trigger('settings:show');
+                }
+                break;
+            case 'indieTabDisable':
+                if ($('.indieTabShow').css('display') === 'none') {
+                    $('.indieTabShow').css('display', 'block');
+                } else {
+                    $('.indieTabShow').css('display', 'none');
+                    App.vent.trigger('movies:list');
+                    App.vent.trigger('settings:show');
+                }
+                break;                           
             case 'activateRandomize':
             case 'activateWatchlist':
                 App.vent.trigger('movies:list');


### PR DESCRIPTION
Fix issue #401 (and #823). Users can now select option to disable Indie or Anime tab.
Option value is saved and tab is hidden/visible according to this value.

Also replace PR #726 which have wrong encoding (it seem) and my previous PR #461 which branch was deleted at some point when I thinked this fix will not be necessary more longer.