### PR TITLE
Unpack properly FFMpeg on UNIXes

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -141,7 +141,7 @@ if (osvar === 'osx64') {
 } else if (osvar === 'linux32') {
     osvar = 'linux-ia32.zip';
 }
-console.log(osvar);
+//console.log(osvar);
 const ffmpegurl = 'https://github.com/iteufel/nwjs-ffmpeg-prebuilt/releases/download/' + nwVersion + '/' + nwVersion + '-' + osvar;
 
 /*************
@@ -322,8 +322,10 @@ gulp.task('unzipffmpeg', () => {
       // Need to check Correct folder on every Nw.js Upgrade as long as we use nwjs Binary directly
       var ffpath = './build/' + pkJson.name + '/' + parsePlatforms() + '/' + pkJson.name + '.app/Contents/Versions/69.0.3497.100';
     } else {
-    var ffpath = './build/' + pkJson.name + '/' + parsePlatforms();
+      var ffpath = './build/' + pkJson.name + '/' + parsePlatforms();
     }
+    if (parsePlatforms()[0].indexOf('win') === -1)
+        ffpath = ffpath + '/lib';
     return gulp.src('./cache/ffmpeg/*.{tar,tar.bz2,tar.gz,zip}')
         .pipe(decompress({ strip: 1 }))
         .pipe(gulp.dest(ffpath))
@@ -343,6 +345,8 @@ gulp.task('unzipffmpegcache', () => {
   } else {
     var platform = parsePlatforms()[0];
     var bin = path.join('cache', nwVersion + '-' + nwFlavor, platform);
+    if (platform.indexOf('win') === -1)
+        bin = bin + '/lib';
   }
     return gulp.src('./cache/ffmpeg/*.{tar,tar.bz2,tar.gz,zip}')
         .pipe(decompress({ strip: 1 }))


### PR DESCRIPTION
Right now, the FFMpeg library is unpacked nearby the PopcornTime
executable, when it expects it in the *lib* folder, except when on
Windows.
This code solve the issue.