### PR TITLE
Fix crash on video playing for Linux64

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -3,7 +3,7 @@
 /********
  * setup *
  ********/
-const nwVersion = '0.33.4',
+const nwVersion = '0.38.1',
     availablePlatforms = ['linux32', 'linux64', 'win32', 'win64', 'osx64'],
     releasesDir = 'build',
     nwFlavor = 'sdk';


### PR DESCRIPTION
This has to be tested on other platforms than Linux64.

Fix the crash on video playing for Linux (Tested on Fedora30) whenever playing any video.

Steps to reproduce the bug with old nwjs version:
- Launch Popcorn time
- Play any video


Fixes popcorn-official/popcorn-desktop#956