### PR TITLE
Fix celebrate various events checkbox

### DIFF
--- a/src/app/templates/settings-container.tpl
+++ b/src/app/templates/settings-container.tpl
@@ -499,8 +499,8 @@
                 <input type="text" size="20" name="overallRatio" value="<%= overallRatio() %>">&nbsp;&nbsp;<em><%= Common.fileSize(Settings.totalDownloaded) %><i class="fa fa-arrow-circle-down"></i><%= Common.fileSize(Settings.totalUploaded) %><i class="fa fa-arrow-circle-up"></i></em>
             </span>
             <span>
-                <input class="settings-checkbox" name="vpnEnabled" id="cb9" type="checkbox" <%=(Settings.vpnEnabled? "checked='checked'":"")%>>
-                <label class="settings-label" for="cb9"><%= i18n.__("Enable VPN") %></label>
+                <input class="settings-checkbox" name="vpnEnabled" id="cb10" type="checkbox" <%=(Settings.vpnEnabled? "checked='checked'":"")%>>
+                <label class="settings-label" for="cb10"><%= i18n.__("Enable VPN") %></label>
             </span>
 
         </div>


### PR DESCRIPTION
"Celebrate various events" checkbox was associated to "Enable VPN"
checkbox (same id) causing the issue to toggle "Enable VPN" instead.

Id is now corrected.

Solve issue #1164 