### PR TITLE
Fix "enable VPN" option to take effect imediatly

### DIFF
--- a/src/app/lib/views/settings_container.js
+++ b/src/app/lib/views/settings_container.js
@@ -317,6 +317,7 @@
                         $('.advanced').css('display', 'none');
                     }
                     break;
+                case 'vpnEnabled':
                 case 'language':
                 case 'watchedCovers':
                     App.vent.trigger('movies:list');


### PR DESCRIPTION
Enable VPN option wasn't taking effect imediatly and was requiring
to reload a view to take effect.
Now movie view is reloaded and padlock icon visibility switch
instantly.

related to #1167 