### PR TITLE
use rimraf.sync() to clean the cache on app close

### DIFF
--- a/src/app/app.js
+++ b/src/app/app.js
@@ -208,11 +208,7 @@ App.onStart = function (options) {
 
 var deleteFolder = function (path) {
 
-  rimraf(path, function (err) {
-      if (err) {
-          console.log(err);
-      }
-  });
+  rimraf.sync(path);
 };
 
 var deleteCookies = function () {


### PR DESCRIPTION
On ubuntu 18.04 was experiencing issue where 8 or 9 time of 10,
rimraf fail to clean the cache folder properly because the app
close before it do it.

This fix do it synchronously, so the app wait for rimraf to
clean the folder before it close