### PR TITLE
Make sure TorrentCache is created & recognized 

### DIFF
--- a/src/app/lib/streamer.js
+++ b/src/app/lib/streamer.js
@@ -35,12 +35,13 @@
 
         initExistTorrents: function() {
             const fs = require('fs');
+            const torrent_cache_dir = App.settings.tmpLocation + path.sep + 'TorrentCache' + path.sep;
             fs.readdir(App.settings.tmpLocation, (err, files) => {
                 files.forEach(file => {
-                    if (/^[a-f0-9]{40}$/i.test(file) && fs.existsSync(App.settings.tmpLocation + '/TorrentCache/' + file)) {
-                        fs.readFile(App.settings.tmpLocation + '/TorrentCache/' + file, 'utf8', (err, data) => {
+                    if (/^[a-f0-9]{40}$/i.test(file) && fs.existsSync(torrent_cache_dir + file)) {
+                        fs.readFile(torrent_cache_dir + file, 'utf8', (err, data) => {
                             this.torrent = App.WebTorrent.add(data, {
-                                path: App.settings.tmpLocation + '/' + file,
+                                path: path.join(App.settings.tmpLocation, file),
                                 maxConns: 5,
                                 dht: true,
                                 announce: Settings.trackers.forced,
@@ -128,11 +129,11 @@
                 }
 
                 this.torrent = App.WebTorrent.add(uri, {
-                    path: App.settings.tmpLocation + '/' + infoHash,
+                    path: path.join(App.settings.tmpLocation, infoHash),
                     announce: Settings.trackers.forced
                 });
                 const fs = require('fs');
-                fs.writeFileSync(App.settings.tmpLocation + '/TorrentCache/' + this.torrent.infoHash, uri);
+                fs.writeFileSync(App.settings.tmpLocation + path.sep + 'TorrentCache' + path.sep + this.torrent.infoHash, uri);
 
                 this.torrent.on('metadata', function () {
                     this.torrentModel.set('torrent', this.torrent);

--- a/src/app/lib/views/main_window.js
+++ b/src/app/lib/views/main_window.js
@@ -221,7 +221,13 @@
         if (!fs.existsSync(Settings.tmpLocation)) {
           fs.mkdir(Settings.tmpLocation, function(err) {
             if (!err || err.errno === "-4075") {
-              //success
+              // Success. Create TorrentCache inside.
+              const torrent_cache_dir = path.join(Settings.tmpLocation, 'TorrentCache');
+              if (!fs.existsSync(torrent_cache_dir)) {
+                fs.mkdir(torrent_cache_dir, function(err) {
+                  if (err && err.errno !== "-4075") { console.log("error creating TorrentCache dir", err); }
+                });
+              }
             } else {
               Settings.tmpLocation = path.join(
                 os.tmpDir(),

--- a/src/app/lib/views/settings_container.js
+++ b/src/app/lib/views/settings_container.js
@@ -581,7 +581,10 @@
         moveTmpLocation: function (location) {
             if (!fs.existsSync(location)) {
                 fs.mkdirSync(location);
-                fs.mkdirSync(location + '/TorrentCache')
+            }
+            const torrent_cache_dir = path.join(location, 'TorrentCache');
+            if (!fs.existsSync(torrent_cache_dir)) {
+                fs.mkdirSync(torrent_cache_dir);
             }
             if (App.settings['deleteTmpOnClose']) {
                 deleteFolder(oldTmpLocation);


### PR DESCRIPTION
Changes:
1. replace hardcoeded '/' with path.join and path.sep.
2. Add additional steps to create TorrentCache directory.

Outcome:

Tested locally on Windows 10. TorrentCache folder is created
automatically in the temp directory.

Playing torrent is normal without error messages #1221.

As a result, download speed section is displayed correctly.