### PR TITLE
Fixing about view social icons and report issue link

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "bootstrap": "~3.3.7",
     "butter-provider": "0.11.0",
     "butter-sanitize": "^0.1.1",
-    "butter-settings-popcorntime.io": "0.0.1",
+    "butter-settings-popcorntime.io": "0.0.3",
     "chromecasts": "1.9.1",
     "defer-request": "0.0.3",
     "dlnacasts2": "0.1.2",

--- a/src/app/lib/views/about.js
+++ b/src/app/lib/views/about.js
@@ -11,8 +11,7 @@
 
         events: {
             'click .close-icon': 'closeAbout',
-            'click #changelog': 'showChangelog',
-            'click .title-issue': 'reportIssue'
+            'click #changelog': 'showChangelog'
         },
 
         onAttach: function () {
@@ -51,10 +50,6 @@
                     nw.Shell.openExternal(Settings.changelogUrl);
                 }
             });
-        },
-
-        reportIssue: function () {
-            App.vent.trigger('issue:new');
         },
 
         closeChangelog: function () {

--- a/src/app/templates/about.tpl
+++ b/src/app/templates/about.tpl
@@ -27,8 +27,7 @@
             <a href="<%= Settings.projectUrl %>" data-toggle="tooltip" data-placement="top" title="<%= Settings.projectUrl %>" class='links site_icon'></span></a>
             <a href='http://twitter.com/<%= Settings.projectTwitter %>' data-toggle="tooltip" data-placement="top" title="twitter.com/<%= Settings.projectTwitter %>" class='links twitter_icon'></span></a>
             <a href='http://www.fb.com/<%= Settings.projectFacebook %>' data-toggle="tooltip" data-placement="top" title="fb.com/<%= Settings.projectFacebook %>" class='links facebook_icon'></span></a>
-            <a href='http://plus.google.com/+<%= Settings.projectGooglePlus %>/posts' data-toggle="tooltip" data-placement="top" title="plus.google.com/+<%= Settings.projectGooglePlus %>" class='links google_icon'></span></a>
-            <a href='<%= Settings.projectUrl %>' data-toggle="tooltip" data-placement="top" title="<%= Settings.projectUrl %>" class='links gitlab_icon'></span></a>
+            <a href='<%= Settings.sourceUrl %>' data-toggle="tooltip" data-placement="top" title="<%= Settings.sourceUrl %>" class='links github_icon'></span></a>
             <a href='<%= Settings.projectBlog %>' data-toggle="tooltip" data-placement="top" title="<%= Settings.projectBlog %>" class='links blog_icon'></span></a>
             <a href='<%= Settings.projectForum %>' data-toggle="tooltip" data-placement="top" title="<%= Settings.projectForum %>" class='links forum_icon'></span></a>
         </div>

--- a/src/app/templates/about.tpl
+++ b/src/app/templates/about.tpl
@@ -13,7 +13,7 @@
         </div>
 
         <div class="title-issue">
-            <a><%= i18n.__("Report an issue") %></a>
+            <a href="<%= Settings.issuesUrl %>" data-toggle="tooltip" data-placement="top" title="<%= i18n.__("Report an issue") %>" class="links" ><%= i18n.__("Report an issue") %></a>
         </div>
 
         <div class="text-about">

--- a/yarn.lock
+++ b/yarn.lock
@@ -927,10 +927,10 @@ butter-sanitize@^0.1.1:
   dependencies:
     sanitizer "^0.1.3"
 
-butter-settings-popcorntime.io@0.0.1:
-  version "0.0.1"
-  resolved "https://registry.yarnpkg.com/butter-settings-popcorntime.io/-/butter-settings-popcorntime.io-0.0.1.tgz#0e158dfe266029d582bd5eaeb63342b776293c95"
-  integrity sha512-7BnaWGMXIfdtgqb1SB0gr0XjlEGUlWETitblkWW9SV2WM7yAmYQB3a5nGWHVtU1a9l9Ozz4I3+Kizbh0phSVoA==
+butter-settings-popcorntime.io@0.0.3:
+  version "0.0.3"
+  resolved "https://registry.yarnpkg.com/butter-settings-popcorntime.io/-/butter-settings-popcorntime.io-0.0.3.tgz#7d0a6242cfc84cc2aa7f42c8f3905ac520a095f8"
+  integrity sha512-HDTp3ywT5Rxtam+lujKoeeQ7uD1hflDh/OQSKoIfVhIuGS2cn4vhYYdCfdblZr0mzD+rlvuIokr4rF3fxCI57g==
 
 "bytebuffer@~3 >=3.5":
   version "3.5.5"


### PR DESCRIPTION
Removing google plus icon.. because the service ended, and
replacing gitlab icon by github one with repo url

##### edit:
Added a commit to replace the call to the built-in report form by just a link to the issue board