### PR TITLE
Fix wrong element size when both bookmark and seen icons as active

### DIFF
--- a/src/app/styl/views/movie_detail.styl
+++ b/src/app/styl/views/movie_detail.styl
@@ -354,9 +354,6 @@
 
 
                 &.selected
-                    height: 18px
-                    position: relative
-
                     &:before
                         content: "\f00c"
                         font-family: "Font Awesome 5 Free"


### PR DESCRIPTION
In the movie details page when a movie had been added to favorites
and the movie was also marked as seen, the CSS rule to style the "seen"
movie cause the favorites and seen icons (_and whole line_) to go
beneath the "watch now" and "watch trailer" buttons.

Just removed a couple of CSS lines that caused the issue