### PR TITLE
Handling error when deleting cache on exit

### DIFF
--- a/src/app/app.js
+++ b/src/app/app.js
@@ -208,7 +208,12 @@ App.onStart = function (options) {
 
 var deleteFolder = function (path) {
 
-  rimraf.sync(path);
+  try {
+    rimraf.sync(path);
+  } catch(e) {
+    win.error('Error when attempting to delete cache');
+    console.log(e);
+  }
 };
 
 var deleteCookies = function () {


### PR DESCRIPTION
Related to issue #1280 and #1202.
Sometimes when user want to exit the app and torrent still in seed,
a blocking error is trown, disabling ability to close the app.

This don't really fix the real issue but handle the error, allowing
the app to close.