### PR TITLE
Enchancement/fix deletefolder rimraf 2

### DIFF
--- a/src/app/app.js
+++ b/src/app/app.js
@@ -279,17 +279,19 @@ win.on('enter-fullscreen', function () {
 
 // Now this function is used via global keys (cmd+q and alt+f4)
 function close() {
-  if (App.settings.deleteTmpOnClose) {
-    deleteFolder(App.settings.tmpLocation);
-  }
-  if (fs.existsSync(path.join(data_path, 'logs.txt'))) {
-    fs.unlinkSync(path.join(data_path, 'logs.txt'));
-  }
-  try {
-    delCache();
-  } catch (e) {
-    win.close(true);
-  }
+  App.WebTorrent.destroy(function () {
+    if (App.settings.deleteTmpOnClose) {
+      deleteFolder(App.settings.tmpLocation);
+    }
+    if (fs.existsSync(path.join(data_path, 'logs.txt'))) {
+      fs.unlinkSync(path.join(data_path, 'logs.txt'));
+    }
+    try {
+      delCache();
+    } catch (e) {
+      win.close(true);
+    }
+  });
 }
 
 // Wipe the tmpFolder when closing the app (this frees up disk space)


### PR DESCRIPTION
Pull Request #1369 was not properly done. 

We have to make sure the WebTorrent is closed before handling with the temp folder.

It's now added to the close function, to make sure that it's actually done we move the close function to the callback of the WebTorrent.destroy() function.

#1280 will be properly fixed by this.