### PR TITLE
Windows 10 native title bar

### DIFF
--- a/package.json
+++ b/package.json
@@ -92,7 +92,7 @@
     "trakt.tv-images": "5.x.x",
     "trakt.tv-matcher": "7.x.x",
     "trakt.tv-ondeck": "7.x.x",
-    "underscore": "^1.8.3",
+    "underscore": "1.8.3",
     "urijs": "1.19.1",
     "video.js": "4.11.4",
     "videojs-youtube": "1.2.10",

--- a/src/app/index.html
+++ b/src/app/index.html
@@ -25,6 +25,7 @@
     <script id="changelog-tpl" src="templates/changelog.tpl" type="text/x-template"></script>
     <script id="disclaimer-tpl" src="templates/disclaimer.tpl" type="text/x-template"></script>
     <script id="settings-container-tpl" src="templates/settings-container.tpl" type="text/x-template"></script>
+    <script id="win-header-tpl" src="templates/windows-titlebar.tpl" type="text/x-template"></script>
     <script id="header-tpl" src="templates/header.tpl" type="text/x-template"></script>
     <script id="movie-detail-tpl" src="templates/movie-detail.tpl" type="text/x-template"></script>
     <script id="show-detail-tpl" src="templates/show-detail.tpl" type="text/x-template"></script>
@@ -105,6 +106,7 @@
 
     <!-- Backbone Views and Controllers -->
     <script src="lib/views/title_bar.js"></script>
+    <script src="lib/views/windows_title_bar.js"></script>
     <script src="lib/views/main_window.js"></script>
 
     <script src="lib/views/movie_detail.js"></script>

--- a/src/app/lib/views/main_window.js
+++ b/src/app/lib/views/main_window.js
@@ -209,7 +209,12 @@
     },
 
     onAttach: function() {
-      this.showChildView('Header', new App.View.TitleBar());
+      if (os.platform() === 'win32') {
+        this.showChildView('Header', new App.View.WindowsTitleBar());
+      } else {
+        this.showChildView('Header', new App.View.TitleBar());
+      }
+
       // Set the app title (for Windows mostly)
       win.title = App.Config.title;
 

--- a/src/app/lib/views/windows_title_bar.js
+++ b/src/app/lib/views/windows_title_bar.js
@@ -1,0 +1,66 @@
+(function (App) {
+  'use strict';
+  var WindowsTitleBar = Marionette.View.extend({
+    template: '#win-header-tpl',
+
+    events: {
+      'click .window-minimize': 'minimize',
+      'click .window-maximize': 'maximize',
+      'click .window-close': 'closeWindow'
+    },
+
+    initialize: function () {
+      this.nativeWindow = win;
+
+      this.nativeWindow.on('maximize', function () {
+        $('.window-maximize').addClass('window-umaximize');
+      });
+
+      this.nativeWindow.on('restore', function () {
+        $('.window-maximize').removeClass('window-umaximize');
+      });
+    },
+
+    maximize: function () {
+      if (this.nativeWindow.isFullscreen) {
+        this.nativeWindow.toggleFullscreen();
+      } else {
+        if (window.screen.availHeight <= this.nativeWindow.height) {
+          this.nativeWindow.restore();
+          if (process.platform === 'win32') {
+            $('.window-maximize').removeClass('window-umaximize');
+          }
+        } else {
+          this.nativeWindow.maximize();
+          if (process.platform === 'win32') {
+            $('.window-maximize').addClass('window-umaximize');
+          }
+        }
+      }
+    },
+
+    minimize: function () {
+      var that = this.nativeWindow;
+      if (AdvSettings.get('minimizeToTray')) {
+        minimizeToTray();
+      } else {
+        that.minimize();
+      }
+    },
+
+    closeWindow: function () {
+      this.nativeWindow.close();
+    },
+
+    onAttach: function () {
+      $('.tooltipped').tooltip({
+        delay: {
+          'show': 800,
+          'hide': 100
+        }
+      });
+    }
+  });
+
+  App.View.WindowsTitleBar = WindowsTitleBar;
+})(window.App);

--- a/src/app/styl/views/app.styl
+++ b/src/app/styl/views/app.styl
@@ -26,6 +26,7 @@ $MovieListPadding = calc(100% - 67px)
 @import 'main_window'
 @import 'initializing'
 @import 'title_bar'
+@import 'windows-titlebar'
 @import 'filter_bar'
 
 @import 'browser/list'

--- a/src/app/styl/views/title_bar.styl
+++ b/src/app/styl/views/title_bar.styl
@@ -3,7 +3,7 @@
     position: absolute
     top: 0
     width: 100%
-    opacity: .97
+    opacity: 1
     height: $TitleHeight
     background-color: $TitleBarBg
     padding: 13px 0 0

--- a/src/app/styl/views/windows-titlebar.styl
+++ b/src/app/styl/views/windows-titlebar.styl
@@ -1,0 +1,103 @@
+.windows-titlebar {
+  position: absolute
+  top: 0
+  left: 0
+  width: 100%
+  height: 32px
+  display: flex
+  align-items: center
+  background-color $BgColor1
+  border-top: 1px solid #000
+  font-size: 12px
+  color: $Text1
+  font-family: $Font
+}
+
+.windows-titlebar .events {
+  position: relative
+  top: 0
+  left: 0
+  margin-left: 10px
+}
+
+.icon {
+  height 16px
+  width  16px
+  margin-left 10px
+}
+
+.windows-titlebar-title {
+  top: initial !important
+  padding-left: 12px !important
+  font-size: inherit !important
+  color: inherit !important
+  text-shadow: black 0 0 0
+}
+
+.window-controls {
+  margin-left: auto
+  display: flex
+  align-items: center
+  -webkit-app-region: no-drag
+}
+
+.window-control {
+  padding: 0
+  height: 31px
+  width: 46px
+  cursor: initial !important
+}
+
+.window-close:hover {
+  background-color: rgba(232, 17, 35, .9) !important
+}
+
+.window-minimize:hover,
+.window-maximize:hover {
+  background-color: #3a3939 !important
+}
+
+.control-icon {
+  width: 100%;
+  height: 100%;
+}
+
+.window-close-icon {
+  background: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='11' height='11' viewBox='0 0 11 11' fill='none'%3E%3Cpath d='M6.279 5.5L11 10.221l-.779.779L5.5 6.279.779 11 0 10.221 4.721 5.5 0 .779.779 0 5.5 4.721 10.221 0 11 .779 6.279 5.5z' fill='%23fff'/%3E%3C/svg%3E") no-repeat 50% 50%
+  background-size: 10px
+}
+
+.window-close:hover .window-close-icon {
+  background: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='11' height='11' viewBox='0 0 11 11' fill='none'%3E%3Cpath d='M6.279 5.5L11 10.221l-.779.779L5.5 6.279.779 11 0 10.221 4.721 5.5 0 .779.779 0 5.5 4.721 10.221 0 11 .779 6.279 5.5z' fill='%23fff'/%3E%3C/svg%3E") no-repeat 50% 50%
+  background-size: 10px
+}
+
+.window-maximize-icon {
+  background: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='11' height='11' viewBox='0 0 11 11' fill='none'%3E%3Cpath d='M11 0v11H0V0h11zM9.899 1.101H1.1V9.9h8.8V1.1z' fill='%23fff'/%3E%3C/svg%3E") no-repeat 50% 50%
+  background-size: 10px
+}
+
+.window-maximize:hover .window-maximize-icon {
+  background: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='11' height='11' viewBox='0 0 11 11' fill='none'%3E%3Cpath d='M11 0v11H0V0h11zM9.899 1.101H1.1V9.9h8.8V1.1z' fill='%23fff'/%3E%3C/svg%3E") no-repeat 50% 50%
+  background-size: 10px
+}
+
+.window-umaximize .window-maximize-icon {
+  background: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='11' height='11' viewBox='0 0 11 11' fill='none'%3E%3Cpath d='M11 8.798H8.798V11H0V2.202h2.202V0H11v8.798zm-3.298-5.5h-6.6v6.6h6.6v-6.6zM9.9 1.1H3.298v1.101h5.5v5.5h1.1v-6.6z' fill='%23fff'/%3E%3C/svg%3E") no-repeat 50% 50%
+  background-size: 10px
+}
+
+.window-umaximize:hover .window-maximize-icon {
+  background: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='11' height='11' viewBox='0 0 11 11' fill='none'%3E%3Cpath d='M11 8.798H8.798V11H0V2.202h2.202V0H11v8.798zm-3.298-5.5h-6.6v6.6h6.6v-6.6zM9.9 1.1H3.298v1.101h5.5v5.5h1.1v-6.6z' fill='%23fff'/%3E%3C/svg%3E") no-repeat 50% 50%
+  background-size: 10px
+}
+
+.window-minimize-icon {
+  background: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='11' height='11' viewBox='0 0 11 11' fill='none'%3E%3Cpath d='M11 4.399V5.5H0V4.399h11z' fill='%23fff'/%3E%3C/svg%3E") no-repeat 50% 50%
+  background-size: 10px
+}
+
+.window-minimize:hover, .window-minimize-icon {
+  background: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='11' height='11' viewBox='0 0 11 11' fill='none'%3E%3Cpath d='M11 4.399V5.5H0V4.399h11z' fill='%23fff'/%3E%3C/svg%3E") no-repeat 50% 50%
+  background-size: 10px
+}

--- a/src/app/templates/main-window.tpl
+++ b/src/app/templates/main-window.tpl
@@ -1,5 +1,5 @@
 <header id="header"></header>
-<div class="dragzone" style="width: 90%; height: 60px; z-index: 11;" id="player_drag"></div>
+<div class="dragzone" style="width: 86%; height: 32px; z-index: 11;" id="player_drag"></div>
 <div class="notification_alert" style="display:none"></div>
 <div id="notification"></div>
 <div id="changelog-container"></div>

--- a/src/app/templates/windows-titlebar.tpl
+++ b/src/app/templates/windows-titlebar.tpl
@@ -1,0 +1,19 @@
+<div class="windows-titlebar">
+  <img class="icon" src="/src/app/images/icon.png" alt="icon">
+
+  <h1 class="windows-titlebar-title"><%= Settings.projectName %></h1>
+
+  <div class="events img-" style="display: block;"></div>
+
+  <div class="window-controls">
+    <button class="window-control window-minimize">
+      <div class="control-icon window-minimize-icon"></div>
+    </button>
+    <button class="window-control window-maximize">
+      <div class="control-icon window-maximize-icon"></div>
+    </button>
+    <button class="window-control window-close">
+      <div class="control-icon window-close-icon"></div>
+    </button>
+  </div>
+</div>

--- a/yarn.lock
+++ b/yarn.lock
@@ -6986,7 +6986,7 @@ unc-path-regex@^0.1.2:
   resolved "https://registry.yarnpkg.com/unc-path-regex/-/unc-path-regex-0.1.2.tgz#e73dd3d7b0d7c5ed86fbac6b0ae7d8c6a69d50fa"
   integrity sha1-5z3T17DXxe2G+6xrCufYxqadUPo=
 
-"underscore@>=1.3.3 <=1.8.3", "underscore@>=1.4.0 <=1.8.3":
+underscore@1.8.3, "underscore@>=1.3.3 <=1.8.3", "underscore@>=1.4.0 <=1.8.3":
   version "1.8.3"
   resolved "https://registry.yarnpkg.com/underscore/-/underscore-1.8.3.tgz#4f3fb53b106e6097fcf9cb4109f2a5e9bdfa5022"
   integrity sha1-Tz+1OxBuYJf8+ctBCfKl6b36UCI=
@@ -6995,11 +6995,6 @@ underscore@>=1.8.3:
   version "1.9.1"
   resolved "https://registry.yarnpkg.com/underscore/-/underscore-1.9.1.tgz#06dce34a0e68a7babc29b365b8e74b8925203961"
   integrity sha512-5/4etnCkd9c8gwgowi5/om/mYO5ajCaOgdzj/oW+0eQV9WxKBDZw5+ycmKmeaTXjInS/W0BzpGLo2xR2aBwZdg==
-
-underscore@^1.8.3:
-  version "1.10.2"
-  resolved "https://registry.yarnpkg.com/underscore/-/underscore-1.10.2.tgz#73d6aa3668f3188e4adb0f1943bd12cfd7efaaaf"
-  integrity sha512-N4P+Q/BuyuEKFJ43B9gYuOj4TQUHXX+j2FqguVOpjkssLUUrnJofCcBccJSCoeturDoZU6GorDTHSvUDlSQbTg==
 
 underscore@~1.4.4:
   version "1.4.4"


### PR DESCRIPTION
Borrowed from https://github.com/geokaralis

Screenshot:
![image](https://user-images.githubusercontent.com/11328895/80261583-2191c980-868b-11ea-98d6-bd4e7d6e2584.png)

Fixes #1320 

Note: 
Event image is placed on the right side of app title, since there's no center position by Windows standard and app icon should always be standard one.
