### PR TITLE
Create TorrentCache at start up

### DIFF
--- a/src/app/lib/views/main_window.js
+++ b/src/app/lib/views/main_window.js
@@ -251,6 +251,12 @@
             }
           });
         }
+        const torrent_cache_dir = path.join(Settings.tmpLocation, 'TorrentCache');
+        if (!fs.existsSync(torrent_cache_dir)) {
+          fs.mkdir(torrent_cache_dir, function (err) {
+            if (err && err.errno !== "-4075") { console.log("error creating TorrentCache dir", err); }
+          });
+        }
 
         status.set({
           status: i18n.__('Set System Theme'),


### PR DESCRIPTION
If one choose to delete cache folder on exit, when the program
starts the next time, the temp folder is created but not the
TorrentCache folder.

This change ensures the TorrentCache folder always gets created.