### PR TITLE
Fix the watchlist updating properly

### DIFF
--- a/src/app/database.js
+++ b/src/app/database.js
@@ -225,7 +225,7 @@ var Database = {
             })
 
         .then(function () {
-            App.vent.trigger('show:watched:' + data.tvdb_id, data);
+            App.vent.trigger('show:watched:' + data.imdb_id, data);
         });
 
     },


### PR DESCRIPTION
The database didn't trigger the right event, that's the reason you had to refresh the movies page in order to see the episode you just watched actually marked as watched.

Issue number #1411 