### PR TITLE
Adding Debian/Ubuntu install instructions to README file

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,34 @@ tap repo, "https://github.com/#{repo}.git"
 cask 'popcorn-time'
 ~~~
 
+#### Linux - Debian/Ubuntu based distros (tested on ubuntu 18.04):  
+
+* Install unzip && dependencies (they should not be always required but some users needed them to make Popcorn Time working) :  
+`sudo apt update && sudo apt install unzip libcanberra-gtk-module libgconf-2-4 libatomic1`
+* Create popcorn-time folder in /opt/ :  
+`sudo mkdir /opt/popcorn-time`
+* Download Popcorn Time archive :  
+`wget https://get.popcorntime.app/repo/build/Popcorn-Time-0.4.4-linux64.zip`
+* Extract the zip in /opt/popcorn-time :  
+`sudo unzip Popcorn-Time-0.4.4-linux64.zip -d /opt/popcorn-time`
+* Create symlink of Popcorn-Time in /usr/bin :  
+`sudo ln -sf /opt/popcorn-time/Popcorn-Time /usr/bin/popcorn-time`
+* Create .desktop file (so the launcher) :  
+`sudo nano /usr/share/applications/popcorntime.desktop`
+* and copy paste the following text in the editor and save  
+
+```desktop
+[Desktop Entry]
+Version = 1.0
+Type = Application
+Terminal = false
+Name = Popcorn Time
+Exec = /usr/bin/popcorn-time
+Icon = /opt/popcorn-time/src/app/images/icon.png
+Categories = Application;
+```
+
+
 ## Getting Involved
 
 Want to report a bug, request a feature, contribute to or translate Popcorn Time? Check out our in-depth guide to [Contributing to Popcorn Time](CONTRIBUTING.md#contributing-to-popcorn-time). We need all the help we can get! You can also join our [community](README.md#community) to keep up-to-date and meet other developers.


### PR DESCRIPTION
Some linux users are looking for installation instructions in
the README and are confused by the "Gettings started" ones.
Adding specific install instructions for Debian/Ubuntu should
avoid this confusion.

Related issues: #1424, #1419, #1417