### PR TITLE
Fix broken update endpoint

### DIFF
--- a/src/app/settings.js
+++ b/src/app/settings.js
@@ -198,18 +198,11 @@ Settings.totalDownloaded = 0;
 Settings.totalUploaded = 0;
 
 Settings.updateEndpoint = {
-  url: 'https://butterproject.org/',
-  index: 0,
-  proxies: [
-    {
-      url: 'https://butterproject.org/',
-      fingerprint: ''
-    },
-    {
-      url: 'https://butterproject.github.io/',
-      fingerprint: ''
-    }
-  ]
+    url: 'https://popcorntime.app/',
+    index: 0,
+    proxies: [{
+        url: 'https://popcorntime.app/'
+    }]
 };
 
 // App Settings


### PR DESCRIPTION
The app fails whenever it attempts to download an update from the old endpoint