### PR TITLE
Show spinner on close when waiting for app to close

### DIFF
--- a/src/app/app.js
+++ b/src/app/app.js
@@ -279,6 +279,8 @@ win.on('enter-fullscreen', function () {
 
 // Now this function is used via global keys (cmd+q and alt+f4)
 function close() {
+  $('.spinner').show();
+
   App.WebTorrent.destroy(function () {
     if (App.settings.deleteTmpOnClose) {
       deleteFolder(App.settings.tmpLocation);


### PR DESCRIPTION
On older and slower hardware, app can take a moment to delete temporary files.