### PR TITLE
Fix #1441 - Settings view not loading when UI is french

### DIFF
--- a/src/app/common.js
+++ b/src/app/common.js
@@ -62,7 +62,7 @@ Common.copyFile = function (source, target, cb) {
 };
 
 Common.fileSize = function (num) {
-    if (isNaN(num)) {
+    if (isNaN(num) || num === null) {
         return;
     }
 


### PR DESCRIPTION
Fix #1441. There is another bug for retrieving overall
download/upload values, so the returned values are null and
this needed to be handled because the unit can't be determined
and it trigger an error when trying to replace 'B' with 'o'.
Because frenchs use Octets instead of Bytes.