### PR TITLE
Fixes #1541, relative path `require` fail on Ubuntu 20.04

### DIFF
--- a/src/app/bootstrap.js
+++ b/src/app/bootstrap.js
@@ -5,6 +5,7 @@
   /* load all the things ! */
   var Q = require('q');
   var fs = require('fs');
+  var path = require('path');
 
   function loadLocalProviders() {
     var appPath = '';
@@ -56,7 +57,7 @@
 
     return App.Npm.providers.map(function(providerPath) {
       win.info('loading npm', providerPath);
-      return loadFromNPM(`./${providerPath}`, fn);
+      return loadFromNPM(path.join(nw.App.startPath, '/src/app/', providerPath), fn);
     });
   }
 

--- a/src/app/bootstrap.js
+++ b/src/app/bootstrap.js
@@ -57,7 +57,7 @@
 
     return App.Npm.providers.map(function(providerPath) {
       win.info('loading npm', providerPath);
-      return loadFromNPM(path.join(nw.App.startPath, '/src/app/', providerPath), fn);
+      return loadFromNPM(path.join(nw.App.startPath, 'src', 'app', providerPath), fn);
     });
   }
 

--- a/src/app/bootstrap.js
+++ b/src/app/bootstrap.js
@@ -52,7 +52,7 @@
   }
 
   function loadProvidersJSON(fn) {
-    App.Npm = require('../../package.json');
+    App.Npm = nw.App.manifest;
 
     return App.Npm.providers.map(function(providerPath) {
       win.info('loading npm', providerPath);
@@ -61,7 +61,7 @@
   }
 
   function loadFromPackageJSON(regex, fn) {
-    App.Npm = require('../../package.json');
+    App.Npm = nw.App.manifest;
 
     var packages = Object.keys(App.Npm.dependencies).filter(function(p) {
       return p.match(regex);


### PR DESCRIPTION
cf . #1541 

For some (still unexplained) reason, in `bootstrap.js`, relative imports ie. `require("./some-relative-path")` fail.

This PR fixes the issue in two ways:

1. Avoiding the import altogether: `require('../../package.json')` is replaced by `nw.App.manifest`.
2. Rewriting relative path to absolute ones.