### PR TITLE
Always close windows after destroying torrent

### DIFF
--- a/src/app/app.js
+++ b/src/app/app.js
@@ -206,23 +206,23 @@ App.onStart = function (options) {
   initTemplates().then(initApp);
 };
 
-var deleteFolder = function (path) {
-  if (typeof path !== 'string') {
+var deleteFolder = function (folderPath) {
+  if (typeof folderPath !== 'string') {
     return;
   }
 
   var files = [];
-  if (fs.existsSync(path)) {
-    files = fs.readdirSync(path);
-    files.forEach(function (file, index) {
-      var curPath = path + '\/' + file;
+  if (fs.existsSync(folderPath)) {
+    files = fs.readdirSync(folderPath);
+    files.forEach(function (file) {
+      var curPath = path.join(folderPath, file);
       if (fs.lstatSync(curPath).isDirectory()) {
         deleteFolder(curPath);
       } else {
         fs.unlinkSync(curPath);
       }
     });
-    fs.rmdirSync(path);
+    fs.rmdirSync(folderPath);
   }
 };
 
@@ -258,9 +258,16 @@ var deleteCookies = function () {
   });
 };
 
-var delCache = function () {
+var deleteCache = function () {
   window.indexedDB.deleteDatabase('cache');
   win.close(true);
+};
+
+var deleteLogs = function() {
+  var dataPath = path.join(data_path, 'logs.txt');
+  if (fs.existsSync(dataPath)) {
+    fs.unlinkSync(dataPath);
+  }
 };
 
 win.on('resize', function (width, height) {
@@ -281,18 +288,56 @@ win.on('enter-fullscreen', function () {
 function close() {
   $('.spinner').show();
 
-  App.WebTorrent.destroy(function () {
-    if (App.settings.deleteTmpOnClose) {
-      deleteFolder(App.settings.tmpLocation);
-    }
-    if (fs.existsSync(path.join(data_path, 'logs.txt'))) {
-      fs.unlinkSync(path.join(data_path, 'logs.txt'));
-    }
+  // If the WebTorrent is destroyed, that means the user has already clicked the close button.
+  // Try to let the WebTorrent destroy from that closure. Even if it fails, the window will close.
+  if (App.WebTorrent.destroyed) {
+    return;
+  }
+
+  // For some reason, WebTorrent does not have a standard way of passing back errors from destroy()
+  // some errors are thrown from the method, some are sent in the callback, and it seems that there
+  // is a possibility for some to be emitted. In order to ensure that we always close the client,
+  // these are all aggregated into a single callback.
+  var destroyWebTorrentAndPerformCleanup = function (cb) {
+    var onError;
+    var cleanup = function () {
+      App.WebTorrent.removeListener('error', onError);
+    };
+    // js hint doesn't allow us to use cleanup before it is defined,
+    // even though we know it will be when this function is called.
+    onError = function (err) {
+      cleanup();
+      cb(err);
+    };
     try {
-      delCache();
-    } catch (e) {
-      win.close(true);
+      App.WebTorrent.once('error', onError);
+      App.WebTorrent.destroy(function (err) {
+        try {
+          if (err) {
+            return onError(err);
+          }
+          if (App.settings.deleteTmpOnClose) {
+            deleteFolder(App.settings.tmpLocation);
+          }
+          deleteLogs();
+          deleteCache();
+        } catch (err) {
+          return onError(err);
+        }
+        cb(null);
+      });
+    } catch (err) {
+      onError(err);
     }
+  };
+
+  destroyWebTorrentAndPerformCleanup(function(err) {
+    if (err) {
+      win.error(err);
+    }
+    // we always want to close the window if the user has asked for it to be closed.
+    // regardless of whether any error is present, win.close should be called
+    win.close(true);
   });
 }
 


### PR DESCRIPTION
Currently, there is a problem where the window may not always close after destroying the torrent. This can occur in one of a few cases:
- `deleteFolder` fails due to the directory not being empty (which is a separate issue not resolved by this PR). this is the most common issue that I have personally experienced
- `deleteLogs` fails due to a filesystem availability error
- `WebTorrent.destroy` throws an error (as noted in the comments in the code, `WebTorrent.destroy` may surface errors through thrown errors, an error event, or the callback).

All of these cases are currently uncaught. In order to ensure that the window _always closes_, I have pulled out the logic for destroying the web torrent (and cleaning up after it) into a function which aggregates the throw, emit, and callback errors into a single callback.

It may be important to continue investigating why we see `deleteFolder` errors in the first place, but this mitigation should ensure that users do not need to use task manager to close the application.

See https://github.com/popcorn-official/popcorn-desktop/issues/1280 for more information

Scenarios tested and verified to work properly:
- Opening and immediately closing the app
- Opening, watching a torrent, leaving it open, and closing the app
- Opening, watching a torrent, closing it (stop button) and closing the app
- Opening, watching a torrent, allowing it to close on its own by finishing the media, and closing the app (even if VLC is still open, but the media is no longer loaded)