### PR TITLE
Small fix for loading.js

### DIFF
--- a/src/app/lib/views/player/loading.js
+++ b/src/app/lib/views/player/loading.js
@@ -199,7 +199,9 @@
       win.info('Loading torrent:', state);
 
       this.ui.stateTextDownload.text(i18n.__(state));
-      this.ui.stateTextStreamUrl.text(streamInfo.get('src').replace('127.0.0.1', Settings.ipAddress));
+      if (streamInfo.get('src')) {
+        this.ui.stateTextStreamUrl.text(streamInfo.get('src').replace('127.0.0.1', Settings.ipAddress));
+      }
       this.ui.stateTextFilename.text(streamInfo.get('filename'));
       this.ui.stateTextSize.text(Common.fileSize(streamInfo.get('size')));
       this.ui.stateTextDownloadedFormatted.text(Common.fileSize(streamInfo.get('downloaded')) + ' / ');

--- a/src/app/styl/views/loading.styl
+++ b/src/app/styl/views/loading.styl
@@ -71,7 +71,7 @@
 
         .loading-progressbar
             position relative
-            margin-bottom 4px
+            margin-bottom 10px
             margin-top 10px
             width 100%
             background-color #bababa
@@ -92,7 +92,7 @@
 
         .playing-progressbar
             position relative
-            margin-bottom 10px
+            margin-bottom 4px
             margin-top 10px
             background-color #bababa
             border-radius 13px


### PR DESCRIPTION
Sometimes when you restart a movie `streamInfo.get('src')` is undefined for some reason so it breaks the loading.js UI code. Added an IF condition so now it doesnt.