### PR TITLE
Remove '/announce' from tracker urls

### DIFF
--- a/src/app/settings.js
+++ b/src/app/settings.js
@@ -91,23 +91,23 @@ Settings.providers = {
 Settings.trackers = {
   blacklisted: ['demonii'],
   forced: [
-    'udp://glotorrents.pw:6969/announce',
-    'udp://tracker.opentrackr.org:1337/announce',
-    'udp://torrent.gresille.org:80/announce',
-    'udp://tracker.openbittorrent.com:1337/announce',
-    'udp://tracker.coppersurfer.tk:6969/announce',
-    'udp://tracker.leechers-paradise.org:6969/announce',
-    'udp://p4p.arenabg.ch:1337/announce',
-    'udp://p4p.arenabg.com:1337/announce',
-    'udp://tracker.internetwarriors.net:1337/announce',
-    'udp://9.rarbg.to:2710/announce',
-    'udp://9.rarbg.me:2710/announce',
-    'udp://exodus.desync.com:6969/announce',
-    'udp://tracker.cyberia.is:6969/announce',
-    'udp://tracker.torrent.eu.org:451/announce',
-    'udp://tracker.open-internet.nl:6969/announce',
-    'wss://tracker.openwebtorrent.com/announce',
-    'wss://tracker.btorrent.xyz/announce'
+    'udp://glotorrents.pw:6969',
+    'udp://tracker.opentrackr.org:1337',
+    'udp://torrent.gresille.org:80',
+    'udp://tracker.openbittorrent.com:1337',
+    'udp://tracker.coppersurfer.tk:6969',
+    'udp://tracker.leechers-paradise.org:6969',
+    'udp://p4p.arenabg.ch:1337',
+    'udp://p4p.arenabg.com:1337',
+    'udp://tracker.internetwarriors.net:1337',
+    'udp://9.rarbg.to:2710',
+    'udp://9.rarbg.me:2710',
+    'udp://exodus.desync.com:6969',
+    'udp://tracker.cyberia.is:6969',
+    'udp://tracker.torrent.eu.org:451',
+    'udp://tracker.open-internet.nl:6969',
+    'wss://tracker.openwebtorrent.com',
+    'wss://tracker.btorrent.xyz'
   ]
 };
 


### PR DESCRIPTION
For some weird reason it seems to cause an issue when you reload something without restarting Popcorn Time and it wont start downloading (also according to webtorrent's devs and other sources '/announce' is redundant for udp trackers)  

&nbsp;

_*&nbsp;I've tried it way too many times and could replicate the issue&fix every time but always on the same device. If you can replicate it, merge, if not.. maybe this whole PR is redundant and just close it or let me know and I'll close it._  

_**&nbsp;Something also seems to remove the majority of the seeds when you reload a torrent, could be related but that wasn't one of my previous PRs it was a pre-existing issue. Not sure for how far back or how to fix it to be honest._