### PR TITLE
Small fix n2

### DIFF
--- a/src/app/lib/views/player/loading.js
+++ b/src/app/lib/views/player/loading.js
@@ -218,9 +218,9 @@
       if (state === 'playingExternally') {
         this.ui.progressbar.hide();
         if (streamInfo && streamInfo.get('device')) {
-          this.ui.cancel_button.css('visibility', 'visible');
           this.ui.vpn.css('display', 'none');
           this.ui.playingbar.css('width', '0%');
+          this.ui.cancel_button.css('visibility', 'visible');
           if (Settings.activateLoCtrl === true) {
             $('.show-pcontrols').removeClass('fa-angle-down').addClass('fa-angle-up').attr("data-original-title", i18n.__('Hide playback controls'));
             this.ui.cancel_button.css('display', 'none');

--- a/src/app/lib/views/player/loading.js
+++ b/src/app/lib/views/player/loading.js
@@ -220,11 +220,11 @@
         if (streamInfo && streamInfo.get('device')) {
           if (Settings.activateLoCtrl === true) {
             $('.show-pcontrols').removeClass('fa-angle-down').addClass('fa-angle-up').attr("data-original-title", i18n.__('Hide playback controls'));
-            this.ui.vpn.css('display', 'none');
             this.ui.cancel_button.css('display', 'none');
             this.ui.controls.css('display', 'block');
             this.ui.playingbarBox.css('display', 'block');
           }
+          this.ui.vpn.css('display', 'none');
           this.ui.playingbar.css('width', '0%');
 
           // Update gui on status update.

--- a/src/app/lib/views/player/loading.js
+++ b/src/app/lib/views/player/loading.js
@@ -218,14 +218,15 @@
       if (state === 'playingExternally') {
         this.ui.progressbar.hide();
         if (streamInfo && streamInfo.get('device')) {
+          this.ui.cancel_button.css('visibility', 'visible');
+          this.ui.vpn.css('display', 'none');
+          this.ui.playingbar.css('width', '0%');
           if (Settings.activateLoCtrl === true) {
             $('.show-pcontrols').removeClass('fa-angle-down').addClass('fa-angle-up').attr("data-original-title", i18n.__('Hide playback controls'));
             this.ui.cancel_button.css('display', 'none');
             this.ui.controls.css('display', 'block');
             this.ui.playingbarBox.css('display', 'block');
           }
-          this.ui.vpn.css('display', 'none');
-          this.ui.playingbar.css('width', '0%');
 
           // Update gui on status update.
           // uses listenTo so event is unsubscribed automatically when loading view closes.

--- a/src/app/settings.js
+++ b/src/app/settings.js
@@ -91,23 +91,23 @@ Settings.providers = {
 Settings.trackers = {
   blacklisted: ['demonii'],
   forced: [
-    'udp://glotorrents.pw:6969/announce',
-    'udp://tracker.opentrackr.org:1337/announce',
-    'udp://torrent.gresille.org:80/announce',
-    'udp://tracker.openbittorrent.com:1337/announce',
-    'udp://tracker.coppersurfer.tk:6969/announce',
-    'udp://tracker.leechers-paradise.org:6969/announce',
-    'udp://p4p.arenabg.ch:1337/announce',
-    'udp://p4p.arenabg.com:1337/announce',
-    'udp://tracker.internetwarriors.net:1337/announce',
-    'udp://9.rarbg.to:2710/announce',
-    'udp://9.rarbg.me:2710/announce',
-    'udp://exodus.desync.com:6969/announce',
-    'udp://tracker.cyberia.is:6969/announce',
-    'udp://tracker.torrent.eu.org:451/announce',
-    'udp://tracker.open-internet.nl:6969/announce',
-    'wss://tracker.openwebtorrent.com/announce',
-    'wss://tracker.btorrent.xyz/announce'
+    'udp://glotorrents.pw:6969',
+    'udp://tracker.opentrackr.org:1337',
+    'udp://torrent.gresille.org:80',
+    'udp://tracker.openbittorrent.com:1337',
+    'udp://tracker.coppersurfer.tk:6969',
+    'udp://tracker.leechers-paradise.org:6969',
+    'udp://p4p.arenabg.ch:1337',
+    'udp://p4p.arenabg.com:1337',
+    'udp://tracker.internetwarriors.net:1337',
+    'udp://9.rarbg.to:2710',
+    'udp://9.rarbg.me:2710',
+    'udp://exodus.desync.com:6969',
+    'udp://tracker.cyberia.is:6969',
+    'udp://tracker.torrent.eu.org:451',
+    'udp://tracker.open-internet.nl:6969',
+    'wss://tracker.openwebtorrent.com',
+    'wss://tracker.btorrent.xyz'
   ]
 };
 


### PR DESCRIPTION
- https://github.com/popcorn-official/popcorn-desktop/pull/1571 broke the hide VPN function when playing externally. Sorry!! All good now.

- Removed redundant `/announce` from forced tracker urls (most of them didnt have it anyway before I edited with https://github.com/popcorn-official/popcorn-desktop/pull/1571)