### PR TITLE
Fix missing poster fetch & torrent collection search engine enable/disable feature

### DIFF
--- a/src/app/lib/views/movie_detail.js
+++ b/src/app/lib/views/movie_detail.js
@@ -47,7 +47,7 @@
 
       curSynopsis = {old: '', crew: '', cast: '', allcast: '', vstatus: null};
 
-      if (!this.model.get('synopsis') || !this.model.get('rating') || this.model.get('rating') == '0' || this.model.get('rating') == '0.0' || !this.model.get('runtime') || this.model.get('runtime') == '0' || !this.model.get('trailer') || !this.model.get('cover') || this.model.get('cover') == 'images/posterholder.png' || !this.model.get('backdrop') || this.model.get('backdrop') == 'images/posterholder.png' || (Settings.translateSynopsis && Settings.language != 'en')) {
+      if (!this.model.get('synopsis') || !this.model.get('rating') || this.model.get('rating') == '0' || this.model.get('rating') == '0.0' || !this.model.get('runtime') || this.model.get('runtime') == '0' || !this.model.get('trailer') || !this.model.get('poster') || this.model.get('poster') == 'images/posterholder.png' || !this.model.get('backdrop') || this.model.get('backdrop') == 'images/posterholder.png' || (Settings.translateSynopsis && Settings.language != 'en')) {
         this.getMetaData();
       }
 
@@ -257,7 +257,7 @@
       (!this.model.get('rating') || this.model.get('rating') == '0' || this.model.get('rating') == '0.0') && movie && movie.vote_average ? this.model.set('rating', movie.vote_average) : null;
       (!this.model.get('runtime') || this.model.get('runtime') == '0') && movie && movie.runtime ? this.model.set('runtime', movie.runtime) : null;
       !this.model.get('trailer') && movie && movie.videos && movie.videos.results && movie.videos.results[0] ? this.model.set('trailer', 'http://www.youtube.com/watch?v=' + movie.videos.results[0].key) : null;
-      (!this.model.get('cover') || this.model.get('cover') == 'images/posterholder.png') && movie && movie.poster_path ? this.model.set('cover', 'http://image.tmdb.org/t/p/w500' + movie.poster_path) : null;
+      (!this.model.get('poster') || this.model.get('poster') == 'images/posterholder.png') && movie && movie.poster_path ? this.model.set('poster', 'http://image.tmdb.org/t/p/w500' + movie.poster_path) : null;
       (!this.model.get('backdrop') || this.model.get('backdrop') == 'images/posterholder.png') && movie && movie.backdrop_path ? this.model.set('backdrop', 'http://image.tmdb.org/t/p/w500' + movie.backdrop_path) : ((!this.model.get('backdrop') || this.model.get('backdrop') == 'images/posterholder.png') && movie && movie.poster_path ? this.model.set('backdrop', 'http://image.tmdb.org/t/p/w500' + movie.poster_path) : null);
       if (movie && movie.credits && movie.credits.cast && movie.credits.crew && (movie.credits.cast[0] || movie.credits.crew[0])) {
         curSynopsis.old = this.model.get('synopsis');

--- a/src/app/lib/views/torrent_collection.js
+++ b/src/app/lib/views/torrent_collection.js
@@ -21,7 +21,11 @@
             'click .online-search': 'onlineSearch',
             'submit #online-form': 'onlineSearch',
             'click .online-back': 'onlineClose',
-            'contextmenu #online-input': 'rightclick_search'
+            'contextmenu #online-input': 'rightclick_search',
+            'change #enable1337x': 'toggle1337x',
+            'change #enableomgtorrents': 'toggleomgtorrents',
+            'change #enablethepiratebay': 'togglethepiratebay',
+            'change #enablerarbg': 'togglerarbg',
         },
 
         initialize: function () {
@@ -56,6 +60,38 @@
             });
         },
 
+        toggle1337x: function () {
+            if (Settings.enable1337x) {
+                AdvSettings.set('enable1337x', false);
+            } else {
+                AdvSettings.set('enable1337x', true);
+            }
+        },
+
+        toggleomgtorrents: function () {
+            if (Settings.enableomgtorrents) {
+                AdvSettings.set('enableomgtorrents', false);
+            } else {
+                AdvSettings.set('enableomgtorrents', true);
+            }
+        },
+
+        togglethepiratebay: function () {
+            if (Settings.enablethepiratebay) {
+                AdvSettings.set('enablethepiratebay', false);
+            } else {
+                AdvSettings.set('enablethepiratebay', true);
+            }
+        },
+
+        togglerarbg: function () {
+            if (Settings.enablerarbg) {
+                AdvSettings.set('enablerarbg', false);
+            } else {
+                AdvSettings.set('enablerarbg', true);
+            }
+        },
+
         onlineSearch: function (e, retry) {
             if (e) {
                 e.preventDefault();
@@ -84,171 +120,179 @@
             console.warn(category);
 
             var leetx = function () {
-                return new Promise(function (resolve) {
-                    var results = [];
-                    setTimeout(function () {
-                        resolve(results);
-                    }, 6000);
-                    var leet = torrentCollection.leet;
-                    leet.search({
-                        query: input.toLocaleLowerCase(),
-                        category: category,
-                        orderBy: 'seeders',
-                        sortBy: 'desc',
-                    }).then(function (data) {
-                        console.debug('1337x search: %s results', data.torrents.length);
-                        var indx = 1, totl = data.length;
-                        data.torrents.forEach(function (item) {
-                            leet.info('https://1337x.to' + item.href).then(function (ldata) {
-                                var itemModel = {
-                                    title: ldata.title,
-                                    magnet: ldata.download.magnet,
-                                    seeds: ldata.seeders,
-                                    peers: ldata.leechers,
-                                    size: ldata.size,
-                                    index: index
-                                };
-                                indx++;
-                                if (item.title.match(/trailer/i) !== null && input.match(/trailer/i) === null) {
-                                    return;
-                                }
-                                results.push(itemModel);
-                                index++;
-                            }).catch(function (err) {
-                                throw 'nope';
+                if (Settings.enable1337x) {
+                    return new Promise(function (resolve) {
+                        var results = [];
+                        setTimeout(function () {
+                            resolve(results);
+                        }, 6000);
+                        var leet = torrentCollection.leet;
+                        leet.search({
+                            query: input.toLocaleLowerCase(),
+                            category: category,
+                            orderBy: 'seeders',
+                            sortBy: 'desc',
+                        }).then(function (data) {
+                            console.debug('1337x search: %s results', data.torrents.length);
+                            var indx = 1, totl = data.length;
+                            data.torrents.forEach(function (item) {
+                                leet.info('https://1337x.to' + item.href).then(function (ldata) {
+                                    var itemModel = {
+                                        title: ldata.title,
+                                        magnet: ldata.download.magnet,
+                                        seeds: ldata.seeders,
+                                        peers: ldata.leechers,
+                                        size: ldata.size,
+                                        index: index
+                                    };
+                                    indx++;
+                                    if (item.title.match(/trailer/i) !== null && input.match(/trailer/i) === null) {
+                                        return;
+                                    }
+                                    results.push(itemModel);
+                                    index++;
+                                }).catch(function (err) {
+                                    throw 'nope';
+                                });
                             });
+                        }).catch(function (err) {
+                            console.error('1337x search:', err);
+                            resolve(results);
                         });
-                    }).catch(function (err) {
-                        console.error('1337x search:', err);
-                        resolve(results);
                     });
-                });
+                }
             };
 
             var omgtorrent = function () {
-                return new Promise(function (resolve) {
-                    var results = [];
-                    setTimeout(function () {
-                        resolve(results);
-                    }, 6000);
-                    var omg = torrentCollection.omg;
-                    omg.search({
-                        query: input.toLocaleLowerCase(),
-                        type: category.toLocaleLowerCase() === 'movies' ? 'films' : 'series',
-                        order: 'seeders',
-                        orderBy: 'desc',
-                    }).then(function (data) {
-                        console.debug('OMG search: %s results', data.torrents.length);
-                        var indx = 1, totl = data.length;
-                        data.torrents.forEach(function (item) {
-                            omg.info(item.href).then(function (ldata) {
+                if (Settings.enableomgtorrents) {
+                    return new Promise(function (resolve) {
+                        var results = [];
+                        setTimeout(function () {
+                            resolve(results);
+                        }, 6000);
+                        var omg = torrentCollection.omg;
+                        omg.search({
+                            query: input.toLocaleLowerCase(),
+                            type: category.toLocaleLowerCase() === 'movies' ? 'films' : 'series',
+                            order: 'seeders',
+                            orderBy: 'desc',
+                        }).then(function (data) {
+                            console.debug('OMG search: %s results', data.torrents.length);
+                            var indx = 1, totl = data.length;
+                            data.torrents.forEach(function (item) {
+                                omg.info(item.href).then(function (ldata) {
+                                    var itemModel = {
+                                        title: ldata.title,
+                                        magnet: ldata.download.magnet,
+                                        seeds: ldata.seeders,
+                                        peers: ldata.leechers,
+                                        size: ldata.size,
+                                        index: index
+                                    };
+                                    indx++;
+                                    if (item.title.match(/trailer/i) !== null && input.match(/trailer/i) === null) {
+                                        return;
+                                    }
+                                    results.push(itemModel);
+                                    index++;
+                                }).catch(function (err) {
+                                    throw 'OMG info failed';
+                                });
+                            });
+                        }).catch(function (err) {
+                            console.error('OMG search:', err);
+                            resolve(results);
+                        });
+                    });
+                }
+            };
+
+            var piratebay = function () {
+                if (Settings.enablethepiratebay) {
+                    return new Promise(function (resolve) {
+                        var results = [];
+                        setTimeout(function () {
+                            resolve(results);
+                        }, 6000);
+                        var tpb = torrentCollection.tpb;
+                        tpb.search(input.toLocaleLowerCase(), {
+                            category: 'video',
+                            page : 0,
+                            orderBy: 'seeds',
+                            sortBy: 'desc'
+                        }).then(function (data) {
+                            console.debug('TPB search: %s results', data.length);
+                            data.forEach(function (item) {
+                                if (!item.category) {
+                                    return;
+                                }
+
                                 var itemModel = {
-                                    title: ldata.title,
-                                    magnet: ldata.download.magnet,
-                                    seeds: ldata.seeders,
-                                    peers: ldata.leechers,
-                                    size: ldata.size,
+                                    title: item.name,
+                                    magnet: item.magnetLink,
+                                    seeds: item.seeders,
+                                    peers: item.leechers,
+                                    size: item.size,
                                     index: index
                                 };
-                                indx++;
-                                if (item.title.match(/trailer/i) !== null && input.match(/trailer/i) === null) {
+
+                                if (item.name.match(/trailer/i) !== null && item.name.match(/trailer/i) === null) {
                                     return;
                                 }
                                 results.push(itemModel);
                                 index++;
-                            }).catch(function (err) {
-                                throw 'OMG info failed';
                             });
+                            resolve(results);
+                        }).catch(function (err) {
+                            console.error('tpb search:', err);
+                            resolve(results);
                         });
-                    }).catch(function (err) {
-                        console.error('OMG search:', err);
-                        resolve(results);
                     });
-                });
-            };
-
-            var piratebay = function () {
-                return new Promise(function (resolve) {
-                    var results = [];
-                    setTimeout(function () {
-                        resolve(results);
-                    }, 6000);
-                    var tpb = torrentCollection.tpb;
-                    tpb.search(input.toLocaleLowerCase(), {
-                        category: 'video',
-                        page : 0,
-                        orderBy: 'seeds',
-                        sortBy: 'desc'
-                    }).then(function (data) {
-                        console.debug('TPB search: %s results', data.length);
-                        data.forEach(function (item) {
-                            if (!item.category) {
-                                return;
-                            }
-
-                            var itemModel = {
-                                title: item.name,
-                                magnet: item.magnetLink,
-                                seeds: item.seeders,
-                                peers: item.leechers,
-                                size: item.size,
-                                index: index
-                            };
-
-                            if (item.name.match(/trailer/i) !== null && item.name.match(/trailer/i) === null) {
-                                return;
-                            }
-                            results.push(itemModel);
-                            index++;
-                        });
-                        resolve(results);
-                    }).catch(function (err) {
-                        console.error('tpb search:', err);
-                        resolve(results);
-                    });
-                });
+                }
             };
 
             var rarbg = function (retry) {
-                return new Promise(function (resolve) {
-                    var results1 = [];
-                    setTimeout(function () {
-                        resolve(results1);
-                    }, 6000);
-                    var rbg = torrentCollection.rbg;
-                    rbg.search({
-                        query: input.toLocaleLowerCase(),
-                        category: category.toLocaleLowerCase() === 'movies' ? 'movies' : 'tv',
-                        sort: 'seeders',
-                        verified: false
-                    }).then(function (results) {
-                        console.debug('rarbg search: %s results', results.length);
-                        results.forEach(function (item) {
-                            var itemModel = {
-                                title: item.title,
-                                magnet: item.download,
-                                seeds: item.seeders,
-                                peers: item.leechers,
-                                size: Common.fileSize(parseInt(item.size)),
-                                index: index
-                            };
-
-                            if (item.title.match(/trailer/i) !== null && input.match(/trailer/i) === null) {
-                                return;
-                            }
-                            results1.push(itemModel);
-                            index++;
-                        });
-                        resolve(results1);
-                    }).catch(function (err) {
-                        console.error('rarbg search:', err);
-                        if (!retry) {
-                            return resolve(rarbg(true));
-                        } else {
+                if (Settings.enablerarbg) {
+                    return new Promise(function (resolve) {
+                        var results1 = [];
+                        setTimeout(function () {
                             resolve(results1);
-                        }
+                        }, 6000);
+                        var rbg = torrentCollection.rbg;
+                        rbg.search({
+                            query: input.toLocaleLowerCase(),
+                            category: category.toLocaleLowerCase() === 'movies' ? 'movies' : 'tv',
+                            sort: 'seeders',
+                            verified: false
+                        }).then(function (results) {
+                            console.debug('rarbg search: %s results', results.length);
+                            results.forEach(function (item) {
+                                var itemModel = {
+                                    title: item.title,
+                                    magnet: item.download,
+                                    seeds: item.seeders,
+                                    peers: item.leechers,
+                                    size: Common.fileSize(parseInt(item.size)),
+                                    index: index
+                                };
+
+                                if (item.title.match(/trailer/i) !== null && input.match(/trailer/i) === null) {
+                                    return;
+                                }
+                                results1.push(itemModel);
+                                index++;
+                            });
+                            resolve(results1);
+                        }).catch(function (err) {
+                            console.error('rarbg search:', err);
+                            if (!retry) {
+                                return resolve(rarbg(true));
+                            } else {
+                                resolve(results1);
+                            }
+                        });
                     });
-                });
+                }
             };
 
             var removeDupes = function (arr) {

--- a/src/app/lib/views/torrent_collection.js
+++ b/src/app/lib/views/torrent_collection.js
@@ -22,10 +22,10 @@
             'submit #online-form': 'onlineSearch',
             'click .online-back': 'onlineClose',
             'contextmenu #online-input': 'rightclick_search',
-            'change #enable1337x': 'toggle1337x',
-            'change #enableomgtorrents': 'toggleomgtorrents',
             'change #enablethepiratebay': 'togglethepiratebay',
+            'change #enable1337x': 'toggle1337x',
             'change #enablerarbg': 'togglerarbg',
+            'change #enableomgtorrents': 'toggleomgtorrents'
         },
 
         initialize: function () {
@@ -60,36 +60,20 @@
             });
         },
 
-        toggle1337x: function () {
-            if (Settings.enable1337x) {
-                AdvSettings.set('enable1337x', false);
-            } else {
-                AdvSettings.set('enable1337x', true);
-            }
-        },
-
-        toggleomgtorrents: function () {
-            if (Settings.enableomgtorrents) {
-                AdvSettings.set('enableomgtorrents', false);
-            } else {
-                AdvSettings.set('enableomgtorrents', true);
-            }
-        },
-
         togglethepiratebay: function () {
-            if (Settings.enablethepiratebay) {
-                AdvSettings.set('enablethepiratebay', false);
-            } else {
-                AdvSettings.set('enablethepiratebay', true);
-            }
+            AdvSettings.set('enablethepiratebay', !Settings.enablethepiratebay);
+        },
+
+        toggle1337x: function () {
+            AdvSettings.set('enable1337x', !Settings.enable1337x);
         },
 
         togglerarbg: function () {
-            if (Settings.enablerarbg) {
-                AdvSettings.set('enablerarbg', false);
-            } else {
-                AdvSettings.set('enablerarbg', true);
-            }
+            AdvSettings.set('enablerarbg', !Settings.enablerarbg);
+        },
+
+        toggleomgtorrents: function () {
+            AdvSettings.set('enableomgtorrents', !Settings.enableomgtorrents);
         },
 
         onlineSearch: function (e, retry) {
@@ -118,94 +102,6 @@
 
             var index = 0;
             console.warn(category);
-
-            var leetx = function () {
-                if (Settings.enable1337x) {
-                    return new Promise(function (resolve) {
-                        var results = [];
-                        setTimeout(function () {
-                            resolve(results);
-                        }, 6000);
-                        var leet = torrentCollection.leet;
-                        leet.search({
-                            query: input.toLocaleLowerCase(),
-                            category: category,
-                            orderBy: 'seeders',
-                            sortBy: 'desc',
-                        }).then(function (data) {
-                            console.debug('1337x search: %s results', data.torrents.length);
-                            var indx = 1, totl = data.length;
-                            data.torrents.forEach(function (item) {
-                                leet.info('https://1337x.to' + item.href).then(function (ldata) {
-                                    var itemModel = {
-                                        title: ldata.title,
-                                        magnet: ldata.download.magnet,
-                                        seeds: ldata.seeders,
-                                        peers: ldata.leechers,
-                                        size: ldata.size,
-                                        index: index
-                                    };
-                                    indx++;
-                                    if (item.title.match(/trailer/i) !== null && input.match(/trailer/i) === null) {
-                                        return;
-                                    }
-                                    results.push(itemModel);
-                                    index++;
-                                }).catch(function (err) {
-                                    throw 'nope';
-                                });
-                            });
-                        }).catch(function (err) {
-                            console.error('1337x search:', err);
-                            resolve(results);
-                        });
-                    });
-                }
-            };
-
-            var omgtorrent = function () {
-                if (Settings.enableomgtorrents) {
-                    return new Promise(function (resolve) {
-                        var results = [];
-                        setTimeout(function () {
-                            resolve(results);
-                        }, 6000);
-                        var omg = torrentCollection.omg;
-                        omg.search({
-                            query: input.toLocaleLowerCase(),
-                            type: category.toLocaleLowerCase() === 'movies' ? 'films' : 'series',
-                            order: 'seeders',
-                            orderBy: 'desc',
-                        }).then(function (data) {
-                            console.debug('OMG search: %s results', data.torrents.length);
-                            var indx = 1, totl = data.length;
-                            data.torrents.forEach(function (item) {
-                                omg.info(item.href).then(function (ldata) {
-                                    var itemModel = {
-                                        title: ldata.title,
-                                        magnet: ldata.download.magnet,
-                                        seeds: ldata.seeders,
-                                        peers: ldata.leechers,
-                                        size: ldata.size,
-                                        index: index
-                                    };
-                                    indx++;
-                                    if (item.title.match(/trailer/i) !== null && input.match(/trailer/i) === null) {
-                                        return;
-                                    }
-                                    results.push(itemModel);
-                                    index++;
-                                }).catch(function (err) {
-                                    throw 'OMG info failed';
-                                });
-                            });
-                        }).catch(function (err) {
-                            console.error('OMG search:', err);
-                            resolve(results);
-                        });
-                    });
-                }
-            };
 
             var piratebay = function () {
                 if (Settings.enablethepiratebay) {
@@ -245,6 +141,50 @@
                             resolve(results);
                         }).catch(function (err) {
                             console.error('tpb search:', err);
+                            resolve(results);
+                        });
+                    });
+                }
+            };
+
+            var leetx = function () {
+                if (Settings.enable1337x) {
+                    return new Promise(function (resolve) {
+                        var results = [];
+                        setTimeout(function () {
+                            resolve(results);
+                        }, 6000);
+                        var leet = torrentCollection.leet;
+                        leet.search({
+                            query: input.toLocaleLowerCase(),
+                            category: category,
+                            orderBy: 'seeders',
+                            sortBy: 'desc',
+                        }).then(function (data) {
+                            console.debug('1337x search: %s results', data.torrents.length);
+                            var indx = 1, totl = data.length;
+                            data.torrents.forEach(function (item) {
+                                leet.info('https://1337x.to' + item.href).then(function (ldata) {
+                                    var itemModel = {
+                                        title: ldata.title,
+                                        magnet: ldata.download.magnet,
+                                        seeds: ldata.seeders,
+                                        peers: ldata.leechers,
+                                        size: ldata.size,
+                                        index: index
+                                    };
+                                    indx++;
+                                    if (item.title.match(/trailer/i) !== null && input.match(/trailer/i) === null) {
+                                        return;
+                                    }
+                                    results.push(itemModel);
+                                    index++;
+                                }).catch(function (err) {
+                                    throw 'nope';
+                                });
+                            });
+                        }).catch(function (err) {
+                            console.error('1337x search:', err);
                             resolve(results);
                         });
                     });
@@ -295,6 +235,50 @@
                 }
             };
 
+            var omgtorrent = function () {
+                if (Settings.enableomgtorrents) {
+                    return new Promise(function (resolve) {
+                        var results = [];
+                        setTimeout(function () {
+                            resolve(results);
+                        }, 6000);
+                        var omg = torrentCollection.omg;
+                        omg.search({
+                            query: input.toLocaleLowerCase(),
+                            type: category.toLocaleLowerCase() === 'movies' ? 'films' : 'series',
+                            order: 'seeders',
+                            orderBy: 'desc',
+                        }).then(function (data) {
+                            console.debug('OMG search: %s results', data.torrents.length);
+                            var indx = 1, totl = data.length;
+                            data.torrents.forEach(function (item) {
+                                omg.info(item.href).then(function (ldata) {
+                                    var itemModel = {
+                                        title: ldata.title,
+                                        magnet: ldata.download.magnet,
+                                        seeds: ldata.seeders,
+                                        peers: ldata.leechers,
+                                        size: ldata.size,
+                                        index: index
+                                    };
+                                    indx++;
+                                    if (item.title.match(/trailer/i) !== null && input.match(/trailer/i) === null) {
+                                        return;
+                                    }
+                                    results.push(itemModel);
+                                    index++;
+                                }).catch(function (err) {
+                                    throw 'OMG info failed';
+                                });
+                            });
+                        }).catch(function (err) {
+                            console.error('OMG search:', err);
+                            resolve(results);
+                        });
+                    });
+                }
+            };
+
             var removeDupes = function (arr) {
                 var found = [];
                 var unique = [];
@@ -320,10 +304,10 @@
 
             $('.notorrents-info,.torrents-info').hide();
             return Promise.all([
-                leetx(),
-                omgtorrent(),
-                rarbg(),
                 piratebay(),
+                leetx(),
+                rarbg(),
+                omgtorrent(),
             ]).then(function (results) {
                 var items = sortBySeeds(removeDupes(results));
                 console.log('search providers: %d results', items.length);

--- a/src/app/lib/views/torrent_collection.js
+++ b/src/app/lib/views/torrent_collection.js
@@ -62,18 +62,22 @@
 
         togglethepiratebay: function () {
             AdvSettings.set('enablethepiratebay', !Settings.enablethepiratebay);
+            $('#online-input').focus();
         },
 
         toggle1337x: function () {
             AdvSettings.set('enable1337x', !Settings.enable1337x);
+            $('#online-input').focus();
         },
 
         togglerarbg: function () {
             AdvSettings.set('enablerarbg', !Settings.enablerarbg);
+            $('#online-input').focus();
         },
 
         toggleomgtorrents: function () {
             AdvSettings.set('enableomgtorrents', !Settings.enableomgtorrents);
+            $('#online-input').focus();
         },
 
         onlineSearch: function (e, retry) {
@@ -99,6 +103,8 @@
             $('.onlinesearch-info>ul.file-list').html('');
 
             $('.online-search').removeClass('fa-search').addClass('fa-spin fa-spinner');
+
+            $('#online-input').blur();
 
             var index = 0;
             console.warn(category);

--- a/src/app/settings.js
+++ b/src/app/settings.js
@@ -199,6 +199,10 @@ Settings.bigPicture = false;
 Settings.activateTorrentCollection = true;
 Settings.activateWatchlist = true;
 Settings.onlineSearchEngine = 'ExtraTorrent';
+Settings.enablethepiratebay = true;
+Settings.enable1337x = true;
+Settings.enablerarbg = true;
+Settings.enableomgtorrents = true;
 
 // Ratio
 Settings.totalDownloaded = 0;

--- a/src/app/styl/views/torrent_collection.styl
+++ b/src/app/styl/views/torrent_collection.styl
@@ -172,7 +172,7 @@
         .onlinesearch-info
             display none
             margin 0 auto
-            height calc(100% - 30px)
+            height calc(100% - 60px)
             color $Text1
             font-family $AlternateFont
             font-size 17px
@@ -186,7 +186,7 @@
                 color $TextError
                 cursor pointer
                 right 7%
-                top 92px
+                top 122px
                 transition color .3s
 
                 &:hover

--- a/src/app/styl/views/torrent_collection.styl
+++ b/src/app/styl/views/torrent_collection.styl
@@ -27,11 +27,12 @@
             
             .search_in
                 margin 12px 0px 24px -96px
-                opacity 0.3
-                transition opacity .1s ease-in
+                opacity 0.8
+                display none
+                position absolute
 
                 &:hover
-                    opacity 0.9
+                    display block
 
                 span
                     color $InputBoxText
@@ -88,6 +89,9 @@
                 cursor text
                 outline 0 !important
                 height 30px
+                &:focus
+                    & ~ .search_in
+                        display block
 
             .online-search
                 margin-left 5px
@@ -172,7 +176,7 @@
         .onlinesearch-info
             display none
             margin 0 auto
-            height calc(100% - 54px)
+            height calc(100% - 30px)
             color $Text1
             font-family $AlternateFont
             font-size 17px
@@ -186,7 +190,7 @@
                 color $TextError
                 cursor pointer
                 right 7%
-                top 116px
+                top 92px
                 transition color .3s
 
                 &:hover

--- a/src/app/styl/views/torrent_collection.styl
+++ b/src/app/styl/views/torrent_collection.styl
@@ -26,7 +26,9 @@
             margin 0 auto
             
             .search_in
-                margin 12px 0px 24px -96px
+                background-color $BgColor1
+                margin 2px 0px 14px -96px
+                padding 10px 0px 10px 0px
                 opacity 0.8
                 display none
                 position absolute

--- a/src/app/styl/views/torrent_collection.styl
+++ b/src/app/styl/views/torrent_collection.styl
@@ -26,31 +26,31 @@
             margin 0 auto
             
             .search_in
-                margin: 12px 0px 24px -96px
-                opacity: 0.3
+                margin 12px 0px 24px -96px
+                opacity 0.3
                 transition opacity .1s ease-in
 
                 &:hover
-                    opacity: 0.9
+                    opacity 0.9
 
                 span
                     color $InputBoxText
                     font-family $Font, $AlternateFont
-                    font-size: 12px
-                    float: left
-                    height: 12px
-                    padding: 0px 10px 10px 10px
-                    vertical-align: top
+                    font-size 12px
+                    float left
+                    height 12px
+                    padding 0px 10px 10px 10px
+                    vertical-align top
 
                     .sengine-checkbox
-                        height: 12px
-                        display: inline-block
-                        cursor: pointer
-                        vertical-align: top
-                        margin-top: 0px
+                        height 12px
+                        display inline-block
+                        cursor pointer
+                        vertical-align top
+                        margin-top 0px
 
                     label
-                        cursor: pointer
+                        cursor pointer
 
             .engine-selector
                 position absolute

--- a/src/app/styl/views/torrent_collection.styl
+++ b/src/app/styl/views/torrent_collection.styl
@@ -24,6 +24,33 @@
             padding-left 140px
             width 460px
             margin 0 auto
+            
+            .search_in
+                margin: 12px 0px 24px -96px
+                opacity: 0.3
+                transition opacity .1s ease-in
+
+                &:hover
+                    opacity: 0.9
+
+                span
+                    color $InputBoxText
+                    font-family $Font, $AlternateFont
+                    font-size: 12px
+                    float: left
+                    height: 12px
+                    padding: 0px 10px 10px 10px
+                    vertical-align: top
+
+                    .sengine-checkbox
+                        height: 12px
+                        display: inline-block
+                        cursor: pointer
+                        vertical-align: top
+                        margin-top: 0px
+
+                    label
+                        cursor: pointer
 
             .engine-selector
                 position absolute

--- a/src/app/styl/views/torrent_collection.styl
+++ b/src/app/styl/views/torrent_collection.styl
@@ -27,8 +27,8 @@
             
             .search_in
                 background-color $BgColor1
-                margin 2px 0px 14px -96px
-                padding 10px 0px 10px 0px
+                margin 3px 0px 15px -96px
+                padding 9px 0px 9px 0px
                 opacity 0.8
                 display none
                 position absolute

--- a/src/app/styl/views/torrent_collection.styl
+++ b/src/app/styl/views/torrent_collection.styl
@@ -172,7 +172,7 @@
         .onlinesearch-info
             display none
             margin 0 auto
-            height calc(100% - 60px)
+            height calc(100% - 54px)
             color $Text1
             font-family $AlternateFont
             font-size 17px
@@ -186,7 +186,7 @@
                 color $TextError
                 cursor pointer
                 right 7%
-                top 122px
+                top 116px
                 transition color .3s
 
                 &:hover

--- a/src/app/templates/torrent_collection.tpl
+++ b/src/app/templates/torrent_collection.tpl
@@ -18,25 +18,25 @@
             <form id="online-form">
                 <input id="online-input" autocomplete="off" size="34" type="text" name="keyword" placeholder="<%= i18n.__('Search for torrent') %>">
                 <i class="fa fa-search online-search"></i>
+                <div class="search_in">
+                    <span>
+                        <input class="sengine-checkbox" name="enablethepiratebay" id="enablethepiratebay" type="checkbox" <%=(Settings.enablethepiratebay? "checked='checked'":"")%>>
+                        <label for="enablethepiratebay"><%= i18n.__("ThePirateBay") %></label>
+                    </span>
+                    <span>
+                        <input class="sengine-checkbox" name="enable1337x" id="enable1337x" type="checkbox" <%=(Settings.enable1337x? "checked='checked'":"")%>>
+                        <label for="enable1337x"><%= i18n.__("1337x") %></label>
+                    </span>
+                    <span>
+                        <input class="sengine-checkbox" name="enablerarbg" id="enablerarbg" type="checkbox" <%=(Settings.enablerarbg? "checked='checked'":"")%>>
+                        <label for="enablerarbg"><%= i18n.__("RARBG") %></label>
+                    </span>
+                    <span>
+                        <input class="sengine-checkbox" name="enableomgtorrents" id="enableomgtorrents" type="checkbox" <%=(Settings.enableomgtorrents? "checked='checked'":"")%>>
+                        <label for="enableomgtorrents"><%= i18n.__("OMGTorrents") %></label>
+                    </span>
+                </div>
             </form>
-            <div class="search_in">
-                <span>
-                    <input class="sengine-checkbox" name="enablethepiratebay" id="enablethepiratebay" type="checkbox" <%=(Settings.enablethepiratebay? "checked='checked'":"")%>>
-                    <label for="enablethepiratebay"><%= i18n.__("ThePirateBay") %></label>
-                </span>
-                <span>
-                    <input class="sengine-checkbox" name="enable1337x" id="enable1337x" type="checkbox" <%=(Settings.enable1337x? "checked='checked'":"")%>>
-                    <label for="enable1337x"><%= i18n.__("1337x") %></label>
-                </span>
-                <span>
-                    <input class="sengine-checkbox" name="enablerarbg" id="enablerarbg" type="checkbox" <%=(Settings.enablerarbg? "checked='checked'":"")%>>
-                    <label for="enablerarbg"><%= i18n.__("RARBG") %></label>
-                </span>
-                <span>
-                    <input class="sengine-checkbox" name="enableomgtorrents" id="enableomgtorrents" type="checkbox" <%=(Settings.enableomgtorrents? "checked='checked'":"")%>>
-                    <label for="enableomgtorrents"><%= i18n.__("OMGTorrents") %></label>
-                </span>
-            </div>
         </div>
 
         <div class="notorrents-info">

--- a/src/app/templates/torrent_collection.tpl
+++ b/src/app/templates/torrent_collection.tpl
@@ -19,6 +19,24 @@
                 <input id="online-input" autocomplete="off" size="34" type="text" name="keyword" placeholder="<%= i18n.__('Search for torrent') %>">
                 <i class="fa fa-search online-search"></i>
             </form>
+            <div class="search_in">
+                <span>
+                    <input class="sengine-checkbox" name="enablethepiratebay" id="enablethepiratebay" type="checkbox" <%=(Settings.enablethepiratebay? "checked='checked'":"")%>>
+                    <label for="enablethepiratebay"><%= i18n.__("ThePirateBay") %></label>
+                </span>
+                <span>
+                    <input class="sengine-checkbox" name="enable1337x" id="enable1337x" type="checkbox" <%=(Settings.enable1337x? "checked='checked'":"")%>>
+                    <label for="enable1337x"><%= i18n.__("1337x") %></label>
+                </span>
+                <span>
+                    <input class="sengine-checkbox" name="enablerarbg" id="enablerarbg" type="checkbox" <%=(Settings.enablerarbg? "checked='checked'":"")%>>
+                    <label for="enablerarbg"><%= i18n.__("RARBG") %></label>
+                </span>
+                <span>
+                    <input class="sengine-checkbox" name="enableomgtorrents" id="enableomgtorrents" type="checkbox" <%=(Settings.enableomgtorrents? "checked='checked'":"")%>>
+                    <label for="enableomgtorrents"><%= i18n.__("OMGTorrents") %></label>
+                </span>
+            </div>
         </div>
 
         <div class="notorrents-info">


### PR DESCRIPTION
* Fix fetching of missing posters in movie-detail view

* Add the ability to enable/disable search engines in the torrent collection
(`torrent_collection.js` looks heavily edited but its mostly some extra indent and rearranging, the added code is far less)