### PR TITLE
Fix missing poster fetch & add torrent collection search engine enable/disable feature

### DIFF
--- a/src/app/lib/views/movie_detail.js
+++ b/src/app/lib/views/movie_detail.js
@@ -43,13 +43,14 @@
 
       healthButton = new Common.HealthButton('.health-icon', this.retrieveTorrentHealth.bind(this));
 
-      //Handle keyboard shortcuts when other views are appended or removed
-
       curSynopsis = {old: '', crew: '', cast: '', allcast: '', vstatus: null};
 
-      if (!this.model.get('synopsis') || !this.model.get('rating') || this.model.get('rating') == '0' || this.model.get('rating') == '0.0' || !this.model.get('runtime') || this.model.get('runtime') == '0' || !this.model.get('trailer') || !this.model.get('cover') || this.model.get('cover') == 'images/posterholder.png' || !this.model.get('backdrop') || this.model.get('backdrop') == 'images/posterholder.png' || (Settings.translateSynopsis && Settings.language != 'en')) {
+      //Check for missing metadata or if Translate Synopsis is enabled and the language set to something other than English and if one, or multiple are true run the corresponding function to try and fetch them
+      if (!this.model.get('synopsis') || !this.model.get('rating') || this.model.get('rating') == '0' || this.model.get('rating') == '0.0' || !this.model.get('runtime') || this.model.get('runtime') == '0' || !this.model.get('trailer') || !this.model.get('poster') || this.model.get('poster') == 'images/posterholder.png' || !this.model.get('backdrop') || this.model.get('backdrop') == 'images/posterholder.png' || (Settings.translateSynopsis && Settings.language != 'en')) {
         this.getMetaData();
       }
+      
+      //Handle keyboard shortcuts when other views are appended or removed
 
       //If a child was removed from above this view
       App.vent.on('viewstack:pop', function() {
@@ -257,7 +258,7 @@
       (!this.model.get('rating') || this.model.get('rating') == '0' || this.model.get('rating') == '0.0') && movie && movie.vote_average ? this.model.set('rating', movie.vote_average) : null;
       (!this.model.get('runtime') || this.model.get('runtime') == '0') && movie && movie.runtime ? this.model.set('runtime', movie.runtime) : null;
       !this.model.get('trailer') && movie && movie.videos && movie.videos.results && movie.videos.results[0] ? this.model.set('trailer', 'http://www.youtube.com/watch?v=' + movie.videos.results[0].key) : null;
-      (!this.model.get('cover') || this.model.get('cover') == 'images/posterholder.png') && movie && movie.poster_path ? this.model.set('cover', 'http://image.tmdb.org/t/p/w500' + movie.poster_path) : null;
+      (!this.model.get('poster') || this.model.get('poster') == 'images/posterholder.png') && movie && movie.poster_path ? this.model.set('poster', 'http://image.tmdb.org/t/p/w500' + movie.poster_path) : null;
       (!this.model.get('backdrop') || this.model.get('backdrop') == 'images/posterholder.png') && movie && movie.backdrop_path ? this.model.set('backdrop', 'http://image.tmdb.org/t/p/w500' + movie.backdrop_path) : ((!this.model.get('backdrop') || this.model.get('backdrop') == 'images/posterholder.png') && movie && movie.poster_path ? this.model.set('backdrop', 'http://image.tmdb.org/t/p/w500' + movie.poster_path) : null);
       if (movie && movie.credits && movie.credits.cast && movie.credits.crew && (movie.credits.cast[0] || movie.credits.crew[0])) {
         curSynopsis.old = this.model.get('synopsis');

--- a/src/app/lib/views/torrent_collection.js
+++ b/src/app/lib/views/torrent_collection.js
@@ -21,7 +21,12 @@
             'click .online-search': 'onlineSearch',
             'submit #online-form': 'onlineSearch',
             'click .online-back': 'onlineClose',
-            'contextmenu #online-input': 'rightclick_search'
+            'contextmenu #online-input': 'rightclick_search',
+            'click .togglesengines': 'togglesengines',
+            'change #enableThepiratebaySearch': 'toggleThepiratebay',
+            'change #enable1337xSearch': 'toggle1337x',
+            'change #enableRarbgSearch': 'toggleRarbg',
+            'change #enableOmgtorrentSearch': 'toggleOmgtorrent'
         },
 
         initialize: function () {
@@ -56,6 +61,32 @@
             });
         },
 
+        togglesengines: function () {
+            if($('.search_in').is(':visible')) {
+                $('.togglesengines').removeClass('fa-caret-up').addClass('fa-caret-down');
+                $('.search_in').css('display', 'none');
+            } else {
+                $('.togglesengines').removeClass('fa-caret-down').addClass('fa-caret-up');
+                $('.search_in').css('display', 'block');
+            }
+        },
+
+        toggleThepiratebay: function () {
+            AdvSettings.set('enableThepiratebaySearch', !Settings.enableThepiratebaySearch);
+        },
+
+        toggle1337x: function () {
+            AdvSettings.set('enable1337xSearch', !Settings.enable1337xSearch);
+        },
+
+        toggleRarbg: function () {
+            AdvSettings.set('enableRarbgSearch', !Settings.enableRarbgSearch);
+        },
+
+        toggleOmgtorrent: function () {
+            AdvSettings.set('enableOmgtorrentSearch', !Settings.enableOmgtorrentSearch);
+        },
+
         onlineSearch: function (e, retry) {
             if (e) {
                 e.preventDefault();
@@ -76,179 +107,193 @@
                 return;
             }
 
+            if($('.search_in').is(':visible')) {
+                $('.togglesengines').removeClass('fa-caret-up').addClass('fa-caret-down');
+                $('.search_in').css('display', 'none');
+            }
+
             $('.onlinesearch-info>ul.file-list').html('');
 
             $('.online-search').removeClass('fa-search').addClass('fa-spin fa-spinner');
+            $('.togglesengines').css('visibility', 'hidden');
 
             var index = 0;
             console.warn(category);
 
-            var leetx = function () {
-                return new Promise(function (resolve) {
-                    var results = [];
-                    setTimeout(function () {
-                        resolve(results);
-                    }, 6000);
-                    var leet = torrentCollection.leet;
-                    leet.search({
-                        query: input.toLocaleLowerCase(),
-                        category: category,
-                        orderBy: 'seeders',
-                        sortBy: 'desc',
-                    }).then(function (data) {
-                        console.debug('1337x search: %s results', data.torrents.length);
-                        var indx = 1, totl = data.length;
-                        data.torrents.forEach(function (item) {
-                            leet.info('https://1337x.to' + item.href).then(function (ldata) {
-                                var itemModel = {
-                                    title: ldata.title,
-                                    magnet: ldata.download.magnet,
-                                    seeds: ldata.seeders,
-                                    peers: ldata.leechers,
-                                    size: ldata.size,
-                                    index: index
-                                };
-                                indx++;
-                                if (item.title.match(/trailer/i) !== null && input.match(/trailer/i) === null) {
-                                    return;
-                                }
-                                results.push(itemModel);
-                                index++;
-                            }).catch(function (err) {
-                                throw 'nope';
-                            });
-                        });
-                    }).catch(function (err) {
-                        console.error('1337x search:', err);
-                        resolve(results);
-                    });
-                });
-            };
-
-            var omgtorrent = function () {
-                return new Promise(function (resolve) {
-                    var results = [];
-                    setTimeout(function () {
-                        resolve(results);
-                    }, 6000);
-                    var omg = torrentCollection.omg;
-                    omg.search({
-                        query: input.toLocaleLowerCase(),
-                        type: category.toLocaleLowerCase() === 'movies' ? 'films' : 'series',
-                        order: 'seeders',
-                        orderBy: 'desc',
-                    }).then(function (data) {
-                        console.debug('OMG search: %s results', data.torrents.length);
-                        var indx = 1, totl = data.length;
-                        data.torrents.forEach(function (item) {
-                            omg.info(item.href).then(function (ldata) {
-                                var itemModel = {
-                                    title: ldata.title,
-                                    magnet: ldata.download.magnet,
-                                    seeds: ldata.seeders,
-                                    peers: ldata.leechers,
-                                    size: ldata.size,
-                                    index: index
-                                };
-                                indx++;
-                                if (item.title.match(/trailer/i) !== null && input.match(/trailer/i) === null) {
-                                    return;
-                                }
-                                results.push(itemModel);
-                                index++;
-                            }).catch(function (err) {
-                                throw 'OMG info failed';
-                            });
-                        });
-                    }).catch(function (err) {
-                        console.error('OMG search:', err);
-                        resolve(results);
-                    });
-                });
-            };
-
             var piratebay = function () {
-                return new Promise(function (resolve) {
-                    var results = [];
-                    setTimeout(function () {
-                        resolve(results);
-                    }, 6000);
-                    var tpb = torrentCollection.tpb;
-                    tpb.search(input.toLocaleLowerCase(), {
-                        category: 'video',
-                        page : 0,
-                        orderBy: 'seeds',
-                        sortBy: 'desc'
-                    }).then(function (data) {
-                        console.debug('TPB search: %s results', data.length);
-                        data.forEach(function (item) {
-                            if (!item.category) {
-                                return;
-                            }
+                if (Settings.enableThepiratebaySearch) {
+                    return new Promise(function (resolve) {
+                        var results = [];
+                        setTimeout(function () {
+                            resolve(results);
+                        }, 6000);
+                        var tpb = torrentCollection.tpb;
+                        tpb.search(input.toLocaleLowerCase(), {
+                            category: 'video',
+                            page : 0,
+                            orderBy: 'seeds',
+                            sortBy: 'desc'
+                        }).then(function (data) {
+                            console.debug('TPB search: %s results', data.length);
+                            data.forEach(function (item) {
+                                if (!item.category) {
+                                    return;
+                                }
 
-                            var itemModel = {
-                                title: item.name,
-                                magnet: item.magnetLink,
-                                seeds: item.seeders,
-                                peers: item.leechers,
-                                size: item.size,
-                                index: index
-                            };
+                                var itemModel = {
+                                    title: item.name,
+                                    magnet: item.magnetLink,
+                                    seeds: item.seeders,
+                                    peers: item.leechers,
+                                    size: item.size,
+                                    index: index
+                                };
 
-                            if (item.name.match(/trailer/i) !== null && item.name.match(/trailer/i) === null) {
-                                return;
-                            }
-                            results.push(itemModel);
-                            index++;
+                                if (item.name.match(/trailer/i) !== null && item.name.match(/trailer/i) === null) {
+                                    return;
+                                }
+                                results.push(itemModel);
+                                index++;
+                            });
+                            resolve(results);
+                        }).catch(function (err) {
+                            console.error('tpb search:', err);
+                            resolve(results);
                         });
-                        resolve(results);
-                    }).catch(function (err) {
-                        console.error('tpb search:', err);
-                        resolve(results);
                     });
-                });
+                }
+            };
+
+            var leetx = function () {
+                if (Settings.enable1337xSearch) {
+                    return new Promise(function (resolve) {
+                        var results = [];
+                        setTimeout(function () {
+                            resolve(results);
+                        }, 6000);
+                        var leet = torrentCollection.leet;
+                        leet.search({
+                            query: input.toLocaleLowerCase(),
+                            category: category,
+                            orderBy: 'seeders',
+                            sortBy: 'desc',
+                        }).then(function (data) {
+                            console.debug('1337x search: %s results', data.torrents.length);
+                            var indx = 1, totl = data.length;
+                            data.torrents.forEach(function (item) {
+                                leet.info('https://1337x.to' + item.href).then(function (ldata) {
+                                    var itemModel = {
+                                        title: ldata.title,
+                                        magnet: ldata.download.magnet,
+                                        seeds: ldata.seeders,
+                                        peers: ldata.leechers,
+                                        size: ldata.size,
+                                        index: index
+                                    };
+                                    indx++;
+                                    if (item.title.match(/trailer/i) !== null && input.match(/trailer/i) === null) {
+                                        return;
+                                    }
+                                    results.push(itemModel);
+                                    index++;
+                                }).catch(function (err) {
+                                    throw 'nope';
+                                });
+                            });
+                        }).catch(function (err) {
+                            console.error('1337x search:', err);
+                            resolve(results);
+                        });
+                    });
+                }
             };
 
             var rarbg = function (retry) {
-                return new Promise(function (resolve) {
-                    var results1 = [];
-                    setTimeout(function () {
-                        resolve(results1);
-                    }, 6000);
-                    var rbg = torrentCollection.rbg;
-                    rbg.search({
-                        query: input.toLocaleLowerCase(),
-                        category: category.toLocaleLowerCase() === 'movies' ? 'movies' : 'tv',
-                        sort: 'seeders',
-                        verified: false
-                    }).then(function (results) {
-                        console.debug('rarbg search: %s results', results.length);
-                        results.forEach(function (item) {
-                            var itemModel = {
-                                title: item.title,
-                                magnet: item.download,
-                                seeds: item.seeders,
-                                peers: item.leechers,
-                                size: Common.fileSize(parseInt(item.size)),
-                                index: index
-                            };
-
-                            if (item.title.match(/trailer/i) !== null && input.match(/trailer/i) === null) {
-                                return;
-                            }
-                            results1.push(itemModel);
-                            index++;
-                        });
-                        resolve(results1);
-                    }).catch(function (err) {
-                        console.error('rarbg search:', err);
-                        if (!retry) {
-                            return resolve(rarbg(true));
-                        } else {
+                if (Settings.enableRarbgSearch) {
+                    return new Promise(function (resolve) {
+                        var results1 = [];
+                        setTimeout(function () {
                             resolve(results1);
-                        }
+                        }, 6000);
+                        var rbg = torrentCollection.rbg;
+                        rbg.search({
+                            query: input.toLocaleLowerCase(),
+                            category: category.toLocaleLowerCase() === 'movies' ? 'movies' : 'tv',
+                            sort: 'seeders',
+                            verified: false
+                        }).then(function (results) {
+                            console.debug('rarbg search: %s results', results.length);
+                            results.forEach(function (item) {
+                                var itemModel = {
+                                    title: item.title,
+                                    magnet: item.download,
+                                    seeds: item.seeders,
+                                    peers: item.leechers,
+                                    size: Common.fileSize(parseInt(item.size)),
+                                    index: index
+                                };
+
+                                if (item.title.match(/trailer/i) !== null && input.match(/trailer/i) === null) {
+                                    return;
+                                }
+                                results1.push(itemModel);
+                                index++;
+                            });
+                            resolve(results1);
+                        }).catch(function (err) {
+                            console.error('rarbg search:', err);
+                            if (!retry) {
+                                return resolve(rarbg(true));
+                            } else {
+                                resolve(results1);
+                            }
+                        });
                     });
-                });
+                }
+            };
+
+            var omgtorrent = function () {
+                if (Settings.enableOmgtorrentSearch) {
+                    return new Promise(function (resolve) {
+                        var results = [];
+                        setTimeout(function () {
+                            resolve(results);
+                        }, 6000);
+                        var omg = torrentCollection.omg;
+                        omg.search({
+                            query: input.toLocaleLowerCase(),
+                            type: category.toLocaleLowerCase() === 'movies' ? 'films' : 'series',
+                            order: 'seeders',
+                            orderBy: 'desc',
+                        }).then(function (data) {
+                            console.debug('OMG search: %s results', data.torrents.length);
+                            var indx = 1, totl = data.length;
+                            data.torrents.forEach(function (item) {
+                                omg.info(item.href).then(function (ldata) {
+                                    var itemModel = {
+                                        title: ldata.title,
+                                        magnet: ldata.download.magnet,
+                                        seeds: ldata.seeders,
+                                        peers: ldata.leechers,
+                                        size: ldata.size,
+                                        index: index
+                                    };
+                                    indx++;
+                                    if (item.title.match(/trailer/i) !== null && input.match(/trailer/i) === null) {
+                                        return;
+                                    }
+                                    results.push(itemModel);
+                                    index++;
+                                }).catch(function (err) {
+                                    throw 'OMG info failed';
+                                });
+                            });
+                        }).catch(function (err) {
+                            console.error('OMG search:', err);
+                            resolve(results);
+                        });
+                    });
+                }
             };
 
             var removeDupes = function (arr) {
@@ -276,10 +321,10 @@
 
             $('.notorrents-info,.torrents-info').hide();
             return Promise.all([
-                leetx(),
-                omgtorrent(),
-                rarbg(),
                 piratebay(),
+                leetx(),
+                rarbg(),
+                omgtorrent(),
             ]).then(function (results) {
                 var items = sortBySeeds(removeDupes(results));
                 console.log('search providers: %d results', items.length);
@@ -288,6 +333,7 @@
                     that.onlineAddItem(item);
                 })).then(function () {
                     $('.online-search').removeClass('fa-spin fa-spinner').addClass('fa-search');
+                    $('.togglesengines').css('visibility', 'visible');
                     $('.onlinesearch-info').show();
 
                     if (items.length === 0) {

--- a/src/app/lib/views/torrent_collection.js
+++ b/src/app/lib/views/torrent_collection.js
@@ -114,17 +114,15 @@
                 $('.togglesengines').removeClass('fa-caret-up').addClass('fa-caret-down');
                 $('.search_in').css('display', 'none');
             }
-
-            $('.onlinesearch-info>ul.file-list').html('');
-
-            $('.online-search').removeClass('fa-search').addClass('fa-spin fa-spinner');
             $('.togglesengines').css('visibility', 'hidden');
+            $('.online-search').removeClass('fa-search').addClass('fa-spin fa-spinner');
             $('.online-search, #enableThepiratebaySearchL, #enable1337xSearchL, #enableRarbgSearchL, #enableOmgtorrentSearchL').attr('title', '0 results').tooltip('fixTitle');
+            $('.onlinesearch-info').hide();
+            $('.onlinesearch-info>ul.file-list').html('');
 
             clearTimeout(hidetooltps);
 
             var index = 0;
-            console.warn(category);
 
             var piratebay = function () {
                 if (Settings.enableThepiratebaySearch) {

--- a/src/app/lib/views/torrent_collection.js
+++ b/src/app/lib/views/torrent_collection.js
@@ -2,7 +2,8 @@
     'use strict';
 
     var clipboard = nw.Clipboard.get(),
-        collection = path.join(data_path + '/TorrentCollection/');
+        collection = path.join(data_path + '/TorrentCollection/'),
+        hidetooltps;
 
     var TorrentCollection = Marionette.View.extend({
         template: '#torrent-collection-tpl',
@@ -52,6 +53,8 @@
                 $('.collection-actions').css('display', 'block');
                 $('.torrents-info').css('display', 'block');
             }
+
+            clearTimeout(hidetooltps);
 
             this.$('.tooltipped').tooltip({
                 delay: {
@@ -116,6 +119,8 @@
 
             $('.online-search').removeClass('fa-search').addClass('fa-spin fa-spinner');
             $('.togglesengines').css('visibility', 'hidden');
+
+            clearTimeout(hidetooltps);
 
             var index = 0;
             console.warn(category);
@@ -332,7 +337,11 @@
             ]).then(function (results) {
                 var items = sortBySeeds(removeDupes(results));
                 console.log('search providers: %d results', items.length);
-                $('.online-search').attr('title', items.length + ' results').tooltip('fixTitle');
+                $('.online-search').attr('title', items.length + ' results').tooltip('fixTitle').tooltip('show');
+
+                hidetooltps = setTimeout(function() {
+                    $('.tooltip').tooltip('hide');
+                }, 2000);
 
                 return Promise.all(items.map(function (item) {
                     that.onlineAddItem(item);

--- a/src/app/lib/views/torrent_collection.js
+++ b/src/app/lib/views/torrent_collection.js
@@ -187,7 +187,7 @@
                         }).then(function (data) {
                             console.debug('1337x search: %s results', data.torrents.length);
                             $('#enable1337xSearchL').attr('title', data.torrents.length + ' results').tooltip('fixTitle');
-                            var indx = 1, totl = data.length;
+                            var indx = 1;
                             data.torrents.forEach(function (item) {
                                 leet.info('https://1337x.to' + item.href).then(function (ldata) {
                                     var itemModel = {
@@ -277,7 +277,7 @@
                         }).then(function (data) {
                             console.debug('OMG search: %s results', data.torrents.length);
                             $('#enableOmgtorrentSearchL').attr('title', data.torrents.length + ' results').tooltip('fixTitle');
-                            var indx = 1, totl = data.length;
+                            var indx = 1;
                             data.torrents.forEach(function (item) {
                                 omg.info(item.href).then(function (ldata) {
                                     var itemModel = {

--- a/src/app/lib/views/torrent_collection.js
+++ b/src/app/lib/views/torrent_collection.js
@@ -138,13 +138,12 @@
                             orderBy: 'seeds',
                             sortBy: 'desc'
                         }).then(function (data) {
-                            console.debug('TPB search: %s results', data.length);
+                            console.debug('ThePirateBay search: %s results', data.length);
                             $('#enableThepiratebaySearchL').attr('title', data.length + ' results').tooltip('fixTitle');
                             data.forEach(function (item) {
                                 if (!item.category) {
                                     return;
                                 }
-
                                 var itemModel = {
                                     title: item.name,
                                     magnet: item.magnetLink,
@@ -153,7 +152,6 @@
                                     size: item.size,
                                     index: index
                                 };
-
                                 if (item.name.match(/trailer/i) !== null && item.name.match(/trailer/i) === null) {
                                     return;
                                 }
@@ -162,7 +160,7 @@
                             });
                             resolve(results);
                         }).catch(function (err) {
-                            console.error('tpb search:', err);
+                            console.error('ThePirateBay search:', err);
                             resolve(results);
                         });
                     });
@@ -181,11 +179,10 @@
                             query: input.toLocaleLowerCase(),
                             category: category,
                             orderBy: 'seeders',
-                            sortBy: 'desc',
+                            sortBy: 'desc'
                         }).then(function (data) {
                             console.debug('1337x search: %s results', data.torrents.length);
                             $('#enable1337xSearchL').attr('title', data.torrents.length + ' results').tooltip('fixTitle');
-                            var indx = 1;
                             data.torrents.forEach(function (item) {
                                 leet.info('https://1337x.to' + item.href).then(function (ldata) {
                                     var itemModel = {
@@ -196,7 +193,6 @@
                                         size: ldata.size,
                                         index: index
                                     };
-                                    indx++;
                                     if (item.title.match(/trailer/i) !== null && input.match(/trailer/i) === null) {
                                         return;
                                     }
@@ -214,12 +210,12 @@
                 }
             };
 
-            var rarbg = function (retry) {
+            var rarbg = function () {
                 if (Settings.enableRarbgSearch) {
                     return new Promise(function (resolve) {
-                        var results1 = [];
+                        var results = [];
                         setTimeout(function () {
-                            resolve(results1);
+                            resolve(results);
                         }, 6000);
                         var rbg = torrentCollection.rbg;
                         rbg.search({
@@ -227,10 +223,10 @@
                             category: category.toLocaleLowerCase() === 'movies' ? 'movies' : 'tv',
                             sort: 'seeders',
                             verified: false
-                        }).then(function (results) {
-                            console.debug('rarbg search: %s results', results.length);
-                            $('#enableRarbgSearchL').attr('title', results.length + ' results').tooltip('fixTitle');
-                            results.forEach(function (item) {
+                        }).then(function (data) {
+                            console.debug('RARBG search: %s results', data.length);
+                            $('#enableRarbgSearchL').attr('title', data.length + ' results').tooltip('fixTitle');
+                            data.forEach(function (item) {
                                 var itemModel = {
                                     title: item.title,
                                     magnet: item.download,
@@ -239,21 +235,15 @@
                                     size: Common.fileSize(parseInt(item.size)),
                                     index: index
                                 };
-
                                 if (item.title.match(/trailer/i) !== null && input.match(/trailer/i) === null) {
                                     return;
                                 }
-                                results1.push(itemModel);
+                                results.push(itemModel);
                                 index++;
                             });
-                            resolve(results1);
                         }).catch(function (err) {
-                            console.error('rarbg search:', err);
-                            if (!retry) {
-                                return resolve(rarbg(true));
-                            } else {
-                                resolve(results1);
-                            }
+                            console.error('RARBG search:', err);
+                            resolve(results);
                         });
                     });
                 }
@@ -271,11 +261,10 @@
                             query: input.toLocaleLowerCase(),
                             type: category.toLocaleLowerCase() === 'movies' ? 'films' : 'series',
                             order: 'seeders',
-                            orderBy: 'desc',
+                            orderBy: 'desc'
                         }).then(function (data) {
-                            console.debug('OMG search: %s results', data.torrents.length);
+                            console.debug('OMGTorrent search: %s results', data.torrents.length);
                             $('#enableOmgtorrentSearchL').attr('title', data.torrents.length + ' results').tooltip('fixTitle');
-                            var indx = 1;
                             data.torrents.forEach(function (item) {
                                 omg.info(item.href).then(function (ldata) {
                                     var itemModel = {
@@ -286,18 +275,17 @@
                                         size: ldata.size,
                                         index: index
                                     };
-                                    indx++;
                                     if (item.title.match(/trailer/i) !== null && input.match(/trailer/i) === null) {
                                         return;
                                     }
                                     results.push(itemModel);
                                     index++;
                                 }).catch(function (err) {
-                                    throw 'OMG info failed';
+                                    throw 'nope';
                                 });
                             });
                         }).catch(function (err) {
-                            console.error('OMG search:', err);
+                            console.error('OMGTorrent search:', err);
                             resolve(results);
                         });
                     });
@@ -335,7 +323,7 @@
                 omgtorrent(),
             ]).then(function (results) {
                 var items = sortBySeeds(removeDupes(results));
-                console.log('search providers: %d results', items.length);
+                console.log('Search Providers: %d results', items.length);
                 $('.online-search').attr('title', items.length + ' results').tooltip('fixTitle').tooltip('show');
 
                 hidetooltps = setTimeout(function() {

--- a/src/app/lib/views/torrent_collection.js
+++ b/src/app/lib/views/torrent_collection.js
@@ -119,6 +119,7 @@
 
             $('.online-search').removeClass('fa-search').addClass('fa-spin fa-spinner');
             $('.togglesengines').css('visibility', 'hidden');
+            $('.online-search, #enableThepiratebaySearchL, #enable1337xSearchL, #enableRarbgSearchL, #enableOmgtorrentSearchL').attr('title', '0 results').tooltip('fixTitle');
 
             clearTimeout(hidetooltps);
 

--- a/src/app/lib/views/torrent_collection.js
+++ b/src/app/lib/views/torrent_collection.js
@@ -135,6 +135,7 @@
                             sortBy: 'desc'
                         }).then(function (data) {
                             console.debug('TPB search: %s results', data.length);
+                            $('#enableThepiratebaySearchL').attr('title', data.length + ' results').tooltip('fixTitle');
                             data.forEach(function (item) {
                                 if (!item.category) {
                                     return;
@@ -179,6 +180,7 @@
                             sortBy: 'desc',
                         }).then(function (data) {
                             console.debug('1337x search: %s results', data.torrents.length);
+                            $('#enable1337xSearchL').attr('title', data.torrents.length + ' results').tooltip('fixTitle');
                             var indx = 1, totl = data.length;
                             data.torrents.forEach(function (item) {
                                 leet.info('https://1337x.to' + item.href).then(function (ldata) {
@@ -223,6 +225,7 @@
                             verified: false
                         }).then(function (results) {
                             console.debug('rarbg search: %s results', results.length);
+                            $('#enableRarbgSearchL').attr('title', results.length + ' results').tooltip('fixTitle');
                             results.forEach(function (item) {
                                 var itemModel = {
                                     title: item.title,
@@ -267,6 +270,7 @@
                             orderBy: 'desc',
                         }).then(function (data) {
                             console.debug('OMG search: %s results', data.torrents.length);
+                            $('#enableOmgtorrentSearchL').attr('title', data.torrents.length + ' results').tooltip('fixTitle');
                             var indx = 1, totl = data.length;
                             data.torrents.forEach(function (item) {
                                 omg.info(item.href).then(function (ldata) {
@@ -328,6 +332,7 @@
             ]).then(function (results) {
                 var items = sortBySeeds(removeDupes(results));
                 console.log('search providers: %d results', items.length);
+                $('.online-search').attr('title', items.length + ' results').tooltip('fixTitle');
 
                 return Promise.all(items.map(function (item) {
                     that.onlineAddItem(item);

--- a/src/app/settings.js
+++ b/src/app/settings.js
@@ -199,6 +199,10 @@ Settings.bigPicture = false;
 Settings.activateTorrentCollection = true;
 Settings.activateWatchlist = true;
 Settings.onlineSearchEngine = 'ExtraTorrent';
+Settings.enableThepiratebaySearch = true;
+Settings.enable1337xSearch = true;
+Settings.enableRarbgSearch = true;
+Settings.enableOmgtorrentSearch = true;
 
 // Ratio
 Settings.totalDownloaded = 0;

--- a/src/app/styl/views/torrent_collection.styl
+++ b/src/app/styl/views/torrent_collection.styl
@@ -31,17 +31,6 @@
             &:hover
                 opacity 0.5
 
-        #savedtorrentslabeltext
-            font-size 36px
-            font-family $MainFontBold
-            font-style normal
-            opacity 0.07
-            left 134px
-            top 134px
-            text-align left
-            position absolute
-            z-index -1
-
         #searchresultslabel
             font-size 48px
             opacity 0.07
@@ -51,6 +40,7 @@
             position absolute
             z-index -1
 
+        #savedtorrentslabeltext,
         #searchresultslabeltext
             font-size 36px
             font-family $MainFontBold

--- a/src/app/styl/views/torrent_collection.styl
+++ b/src/app/styl/views/torrent_collection.styl
@@ -232,13 +232,12 @@
         .torrents-info,
         .onlinesearch-info
             display none
-            margin 0 auto
-            height calc(100% - 30px)
+            margin 60px auto
+            height calc(100% - 90px)
             color $Text1
             font-family $AlternateFont
             font-size 17px
             text-align center
-            box-shadow inset -3px 0px 10px $FileSelectorShadow
             scrollable()
 
             .online-back
@@ -247,7 +246,7 @@
                 color $TextError
                 cursor pointer
                 right 7%
-                top 92px
+                top 152px
                 transition color .3s
 
                 &:hover

--- a/src/app/styl/views/torrent_collection.styl
+++ b/src/app/styl/views/torrent_collection.styl
@@ -42,7 +42,7 @@
                     height 12px
                     padding 0px 8px 10px 8px
                     vertical-align top
-                    opacity 0.75
+                    opacity 0.85
                     margin-top 1px
                     transition opacity .1s ease-in
 
@@ -69,8 +69,13 @@
                         vertical-align middle
                         cursor pointer
                         color $SettingsText1
+                        opacity 0.5
+
+                        &:hover
+                            opacity 1
 
                     &.sengine-checkbox:checked+label
+                        opacity 1
                         &:after
                             opacity 1
 

--- a/src/app/styl/views/torrent_collection.styl
+++ b/src/app/styl/views/torrent_collection.styl
@@ -26,10 +26,6 @@
             text-align left
             position absolute
             z-index -1
-            cursor pointer
-
-            &:hover
-                opacity 0.5
 
         #searchresultslabel
             font-size 48px

--- a/src/app/styl/views/torrent_collection.styl
+++ b/src/app/styl/views/torrent_collection.styl
@@ -24,6 +24,79 @@
             padding-left 140px
             width 460px
             margin 0 auto
+            
+            .search_in
+                background-color $InputBoxBg
+                margin 0px 0px 15px -88px
+                padding 9px 0px 9px 2px
+                display none
+                position absolute
+                height 30px
+                min-width 352px
+
+                span
+                    color $InputBoxText
+                    font-family $MainFont
+                    font-size 12px
+                    float left
+                    height 12px
+                    padding 0px 8px 10px 8px
+                    vertical-align top
+                    opacity 0.75
+                    margin-top 1px
+                    transition opacity .1s ease-in
+
+                    &:hover
+                        opacity 1
+
+                input[type=checkbox]
+                    &.sengine-checkbox
+                        position absolute
+                        overflow hidden
+                        clip rect(0 0 0 0)
+                        height 1px
+                        width 1px
+                        margin -1px
+                        padding 0
+                        border 0
+
+                    &.sengine-checkbox+label
+                        height 12px
+                        display inline-block
+                        line-height 12px
+                        font-size 12px
+                        font-family $MainFont
+                        vertical-align middle
+                        cursor pointer
+                        color $SettingsText1
+
+                    &.sengine-checkbox:checked+label
+                        &:after
+                            opacity 1
+
+                .label
+                    &:before
+                        content '\f0c8'
+                        font-family "Font Awesome 5 Free"
+                        font-weight 900
+                        font-size 12px
+                        padding-right 5px
+                        margin-left -1px
+                        float left
+                        position relative
+                        color $CheckboxBg
+                    &:after
+                        content '\f00c'
+                        font-family "Font Awesome 5 Free"
+                        font-weight 900
+                        font-size 10px
+                        margin-right -14px
+                        color $CheckboxCheck
+                        position relative
+                        float left
+                        left -15px
+                        opacity 0
+                        transition opacity .1s ease-in-out
 
             .engine-selector
                 position absolute
@@ -70,10 +143,20 @@
                 &:hover
                     color: $ButtonBgHover
 
+            .togglesengines
+                cursor pointer
+                transition color .3s
+
+                &:hover
+                    color: $ButtonBgHover
+
             .dropdown
                 position absolute
                 margin-top 9px
                 margin-left -88px
+                border-bottom 3px solid $BgColor1
+                border-right 3px solid $BgColor1
+                z-index 1000
 
                 select
                     position relative

--- a/src/app/styl/views/torrent_collection.styl
+++ b/src/app/styl/views/torrent_collection.styl
@@ -18,6 +18,50 @@
         font-family $AlternateFont
         font-size 17px
 
+        #savedtorrentslabel
+            font-size 50px
+            opacity 0.07
+            left 80px
+            top 122px
+            text-align left
+            position absolute
+            z-index -1
+            cursor pointer
+
+            &:hover
+                opacity 0.5
+
+        #savedtorrentslabeltext
+            font-size 36px
+            font-family $MainFontBold
+            font-style normal
+            opacity 0.07
+            left 134px
+            top 134px
+            text-align left
+            position absolute
+            z-index -1
+
+        #searchresultslabel
+            font-size 48px
+            opacity 0.07
+            left 80px
+            top 126px
+            text-align left
+            position absolute
+            z-index -1
+
+        #searchresultslabeltext
+            font-size 36px
+            font-family $MainFontBold
+            font-style normal
+            opacity 0.07
+            left 134px
+            top 134px
+            text-align left
+            position absolute
+            z-index -1
+
         .onlinesearch
             position relative
             top -10px

--- a/src/app/templates/torrent_collection.tpl
+++ b/src/app/templates/torrent_collection.tpl
@@ -17,24 +17,24 @@
             </div>
             <form id="online-form">
                 <input id="online-input" autocomplete="off" size="34" type="text" name="keyword" placeholder="<%= i18n.__('Search for torrent') %>">
-                <i class="fa fa-search online-search"></i>
+                <i class="fa fa-search online-search tooltipped" data-placement="bottom" data-toogle="tooltip"></i>
                 <i class="fa fa-caret-down togglesengines"></i>
                 <div class="search_in">
                     <span>
                         <input class="sengine-checkbox" name="enableThepiratebaySearch" id="enableThepiratebaySearch" type="checkbox" <%=(Settings.enableThepiratebaySearch? "checked='checked'":"")%>>
-                        <label for="enableThepiratebaySearch"><%= i18n.__("ThePirateBay") %></label>
+                        <label id="enableThepiratebaySearchL" for="enableThepiratebaySearch" class="tooltipped" data-placement="bottom" data-toogle="tooltip"><%= i18n.__("ThePirateBay") %></label>
                     </span>
                     <span>
                         <input class="sengine-checkbox" name="enable1337xSearch" id="enable1337xSearch" type="checkbox" <%=(Settings.enable1337xSearch? "checked='checked'":"")%>>
-                        <label for="enable1337xSearch"><%= i18n.__("1337x") %></label>
+                        <label id="enable1337xSearchL" for="enable1337xSearch" class="tooltipped" data-placement="bottom" data-toogle="tooltip"><%= i18n.__("1337x") %></label>
                     </span>
                     <span>
                         <input class="sengine-checkbox" name="enableRarbgSearch" id="enableRarbgSearch" type="checkbox" <%=(Settings.enableRarbgSearch? "checked='checked'":"")%>>
-                        <label for="enableRarbgSearch"><%= i18n.__("RARBG") %></label>
+                        <label id="enableRarbgSearchL" for="enableRarbgSearch" class="tooltipped" data-placement="bottom" data-toogle="tooltip"><%= i18n.__("RARBG") %></label>
                     </span>
                     <span>
                         <input class="sengine-checkbox" name="enableOmgtorrentSearch" id="enableOmgtorrentSearch" type="checkbox" <%=(Settings.enableOmgtorrentSearch? "checked='checked'":"")%>>
-                        <label for="enableOmgtorrentSearch"><%= i18n.__("OMGTorrent") %></label>
+                        <label id="enableOmgtorrentSearchL" for="enableOmgtorrentSearch" class="tooltipped" data-placement="bottom" data-toogle="tooltip"><%= i18n.__("OMGTorrent") %></label>
                     </span>
                 </div>
             </form>

--- a/src/app/templates/torrent_collection.tpl
+++ b/src/app/templates/torrent_collection.tpl
@@ -18,6 +18,25 @@
             <form id="online-form">
                 <input id="online-input" autocomplete="off" size="34" type="text" name="keyword" placeholder="<%= i18n.__('Search for torrent') %>">
                 <i class="fa fa-search online-search"></i>
+                <i class="fa fa-caret-down togglesengines"></i>
+                <div class="search_in">
+                    <span>
+                        <input class="sengine-checkbox" name="enableThepiratebaySearch" id="enableThepiratebaySearch" type="checkbox" <%=(Settings.enableThepiratebaySearch? "checked='checked'":"")%>>
+                        <label for="enableThepiratebaySearch"><%= i18n.__("ThePirateBay") %></label>
+                    </span>
+                    <span>
+                        <input class="sengine-checkbox" name="enable1337xSearch" id="enable1337xSearch" type="checkbox" <%=(Settings.enable1337xSearch? "checked='checked'":"")%>>
+                        <label for="enable1337xSearch"><%= i18n.__("1337x") %></label>
+                    </span>
+                    <span>
+                        <input class="sengine-checkbox" name="enableRarbgSearch" id="enableRarbgSearch" type="checkbox" <%=(Settings.enableRarbgSearch? "checked='checked'":"")%>>
+                        <label for="enableRarbgSearch"><%= i18n.__("RARBG") %></label>
+                    </span>
+                    <span>
+                        <input class="sengine-checkbox" name="enableOmgtorrentSearch" id="enableOmgtorrentSearch" type="checkbox" <%=(Settings.enableOmgtorrentSearch? "checked='checked'":"")%>>
+                        <label for="enableOmgtorrentSearch"><%= i18n.__("OMGTorrent") %></label>
+                    </span>
+                </div>
             </form>
         </div>
 

--- a/src/app/templates/torrent_collection.tpl
+++ b/src/app/templates/torrent_collection.tpl
@@ -48,7 +48,7 @@
         </div>
 
         <div class="torrents-info">
-            <i class="collection-open fa fa-database tooltipped" data-toggle="tooltip" data-placement="right" title="<%= i18n.__("Open Torrent Collection Folder") %>" id="savedtorrentslabel"></i>
+            <i class="fa fa-database" id="savedtorrentslabel"></i>
             <i id="savedtorrentslabeltext"><%=i18n.__("Saved Torrents") %></i>
             <ul class="file-list">
                 <% _.each(fs.readdirSync(data_path + '/TorrentCollection/'), function(file, index) { %>

--- a/src/app/templates/torrent_collection.tpl
+++ b/src/app/templates/torrent_collection.tpl
@@ -69,7 +69,7 @@
         </div>
 
         <div class="onlinesearch-info">
-            <i class="fa fa-search" style="font-size:50px;opacity:0.07;left:80px;top:122px;text-align:left;position:absolute;z-index:-1;"></i>
+            <i class="fa fa-search" style="font-size:48px;opacity:0.07;left:80px;top:126px;text-align:left;position:absolute;z-index:-1;"></i>
             <i style="font-size:36px;font-family:Open Sans Bold;font-style:normal;opacity:0.07;left:134px;top:134px;text-align:left;position:absolute;z-index:-1;"><%=i18n.__("Search Results") %></i>
             <i class="fa fa-arrow-circle-left online-back"></i>
             <ul class="file-list">

--- a/src/app/templates/torrent_collection.tpl
+++ b/src/app/templates/torrent_collection.tpl
@@ -48,8 +48,8 @@
         </div>
 
         <div class="torrents-info">
-            <i class="collection-open fa fa-database tooltipped" data-toggle="tooltip" data-placement="right" title="<%= i18n.__("Open Torrent Collection Folder") %>" style="font-size:50px;opacity:0.07;left:80px;top:122px;text-align:left;position:absolute;z-index:-1;cursor:pointer;" onmouseover="this.style.opacity=0.5" onmouseout="this.style.opacity=0.07"></i>
-            <i style="font-size:36px;font-family:Open Sans Bold;font-style:normal;opacity:0.07;left:134px;top:134px;text-align:left;position:absolute;z-index:-1;"><%=i18n.__("Saved Torrents") %></i>
+            <i class="collection-open fa fa-database tooltipped" data-toggle="tooltip" data-placement="right" title="<%= i18n.__("Open Torrent Collection Folder") %>" id="savedtorrentslabel"></i>
+            <i id="savedtorrentslabeltext"><%=i18n.__("Saved Torrents") %></i>
             <ul class="file-list">
                 <% _.each(fs.readdirSync(data_path + '/TorrentCollection/'), function(file, index) { %>
                     <li class="file-item" data-index="<%=file.index%>" data-file="<%=index%>">
@@ -69,8 +69,8 @@
         </div>
 
         <div class="onlinesearch-info">
-            <i class="fa fa-search" style="font-size:48px;opacity:0.07;left:80px;top:126px;text-align:left;position:absolute;z-index:-1;"></i>
-            <i style="font-size:36px;font-family:Open Sans Bold;font-style:normal;opacity:0.07;left:134px;top:134px;text-align:left;position:absolute;z-index:-1;"><%=i18n.__("Search Results") %></i>
+            <i class="fa fa-search" id="searchresultslabel"></i>
+            <i id="searchresultslabeltext"><%=i18n.__("Search Results") %></i>
             <i class="fa fa-arrow-circle-left online-back"></i>
             <ul class="file-list">
             </ul>

--- a/src/app/templates/torrent_collection.tpl
+++ b/src/app/templates/torrent_collection.tpl
@@ -48,6 +48,8 @@
         </div>
 
         <div class="torrents-info">
+            <i class="collection-open fa fa-database tooltipped" data-toggle="tooltip" data-placement="right" title="<%= i18n.__("Open Torrent Collection Folder") %>" style="font-size:50px;opacity:0.07;left:80px;top:122px;text-align:left;position:absolute;z-index:-1;cursor:pointer;" onmouseover="this.style.opacity=0.5" onmouseout="this.style.opacity=0.07"></i>
+            <i style="font-size:36px;font-family:Open Sans Bold;font-style:normal;opacity:0.07;left:134px;top:134px;text-align:left;position:absolute;z-index:-1;"><%=i18n.__("Saved Torrents") %></i>
             <ul class="file-list">
                 <% _.each(fs.readdirSync(data_path + '/TorrentCollection/'), function(file, index) { %>
                     <li class="file-item" data-index="<%=file.index%>" data-file="<%=index%>">
@@ -67,6 +69,8 @@
         </div>
 
         <div class="onlinesearch-info">
+            <i class="fa fa-search" style="font-size:50px;opacity:0.07;left:80px;top:122px;text-align:left;position:absolute;z-index:-1;"></i>
+            <i style="font-size:36px;font-family:Open Sans Bold;font-style:normal;opacity:0.07;left:134px;top:134px;text-align:left;position:absolute;z-index:-1;"><%=i18n.__("Search Results") %></i>
             <i class="fa fa-arrow-circle-left online-back"></i>
             <ul class="file-list">
             </ul>


### PR DESCRIPTION
* Fix fetching of missing posters in movie_detail view

* Add the ability to enable/disable search engines in the Torrent Collection

* Add tooltips with the number of search results in the Torrent Collection

* Add 'Search Results' and 'Saved Torrents' labels in the Torrent Collection

(*`torrent_collection.js` looks heavily edited but after https://github.com/popcorn-official/popcorn-desktop/pull/1585/files#diff-f7847d725e4a233b43d20b518bc499ceR124 is basically some extra indent and rearranging, the total added code is far less than what it looks like in github's diff, also opened a new PR to clean up the commits, had become a mess)