### PR TITLE
Fix watch now btn not working on series episodes

### DIFF
--- a/src/app/lib/views/show_detail.js
+++ b/src/app/lib/views/show_detail.js
@@ -449,7 +449,7 @@
                         extract_subtitle: {
                             type: 'show',
                             imdbid: that.model.get('imdb_id'),
-                            tvdbid: value.tvdb_id.toString(),
+                            tvdbid: (value.tvdb_id || '').toString(),
                             season: value.season,
                             episode: value.episode
                         },


### PR DESCRIPTION
Fixes #1547, fixes #1531, fixes #1530, fixes #1340 

tvdb_id value is sometimes null/undefined and a toString() is called on
it, which causes a crash. This happens if autoplay next episode is
selected in config.

Error shown in console was
<img width="786" alt="Screen Shot 2020-08-02 at 23 58 59" src="https://user-images.githubusercontent.com/9000343/89215880-c7fd3d00-d59f-11ea-9be7-f1975f9663d6.png">


This PR addresses this issue, checking if the value is defined before
calling toString(). In case it's undefined a blank string is used.