### PR TITLE
Misc fixes

### DIFF
--- a/src/app/lib/config.js
+++ b/src/app/lib/config.js
@@ -48,7 +48,7 @@
 
     types_anime: ['All', 'Movies', 'TV', 'OVA', 'ONA'],
 
-    types_fav: ['All', 'Movies', 'TV', 'Anime'],
+    types_fav: ['All', 'Movies', 'Series', 'Anime'],
 
     genres_anime: [
       'All',

--- a/src/app/lib/providers/favorites.js
+++ b/src/app/lib/providers/favorites.js
@@ -172,7 +172,7 @@
         var params = {
             page: filters.page
         };
-        if (filters.type === 'TV') {
+        if (filters.type === 'Series') {
             params.type = 'show';
         }
         if (filters.type === 'Movies') {

--- a/src/app/lib/views/browser/filter_bar.js
+++ b/src/app/lib/views/browser/filter_bar.js
@@ -430,31 +430,13 @@
 
     showFavorites: function(e) {
       e.preventDefault();
-
-      if (App.currentview !== 'Favorites') {
-        App.previousview = App.currentview;
-        App.currentview = 'Favorites';
-        App.vent.trigger('about:close');
-        App.vent.trigger('torrentCollection:close');
-        App.vent.trigger('seedbox:close');
-        App.vent.trigger('favorites:list', []);
-        this.setActive('Favorites');
-      } else {
-        if (
-          $('#movie-detail').html().length === 0 &&
-          $('#about-container').html().length === 0
-        ) {
-          App.currentview = App.previousview;
-          App.vent.trigger(App.previousview.toLowerCase() + ':list', []);
-          this.setActive(App.currentview);
-        } else {
-          App.vent.trigger('about:close');
-          App.vent.trigger('torrentCollection:close');
-          App.vent.trigger('seedbox:close');
-          App.vent.trigger('favorites:list', []);
-          this.setActive('Favorites');
-        }
-      }
+      App.previousview = App.currentview;
+      App.currentview = 'Favorites';
+      App.vent.trigger('about:close');
+      App.vent.trigger('torrentCollection:close');
+      App.vent.trigger('seedbox:close');
+      App.vent.trigger('favorites:list', []);
+      this.setActive('Favorites');
     },
 
     showWatchlist: function(e) {

--- a/src/app/lib/views/browser/filter_bar.js
+++ b/src/app/lib/views/browser/filter_bar.js
@@ -368,7 +368,6 @@
 
     showTorrentCollection: function(e) {
       e.preventDefault();
-
       if (App.currentview !== 'Torrent-collection') {
         App.previousview = App.currentview;
         App.currentview = 'Torrent-collection';
@@ -417,9 +416,9 @@
       App.vent.trigger('anime:list', []);
       this.setActive('Anime');
     },
+    
     movieTabShow: function(e) {
       e.preventDefault();
-
       App.currentview = 'movies';
       App.vent.trigger('about:close');
       App.vent.trigger('torrentCollection:close');
@@ -441,7 +440,6 @@
 
     showWatchlist: function(e) {
       e.preventDefault();
-
       if (App.currentview !== 'Watchlist') {
         App.previousview = App.currentview;
         App.currentview = 'Watchlist';

--- a/src/app/lib/views/browser/filter_bar.js
+++ b/src/app/lib/views/browser/filter_bar.js
@@ -416,7 +416,7 @@
       App.vent.trigger('anime:list', []);
       this.setActive('Anime');
     },
-    
+
     movieTabShow: function(e) {
       e.preventDefault();
       App.currentview = 'movies';

--- a/src/app/lib/views/browser/list.js
+++ b/src/app/lib/views/browser/list.js
@@ -166,8 +166,8 @@
                             $('.source.animeTabShow').addClass('active');
                             break;
                         case 'anime':
-                            App.currentview = 'favorites';
-                            App.vent.trigger(App.currentview + ':list', []);
+                            App.currentview = 'Favorites';
+                            App.vent.trigger('favorites:list', []);
                             $('#filterbar-favorites').addClass('active');
                             break;
                         default:
@@ -178,11 +178,11 @@
                     } else if (combo === 'shift+tab') {
                         switch (App.currentview) {
                         case 'movies':
-                            App.currentview = 'favorites';
-                            App.vent.trigger(App.currentview + ':list', []);
+                            App.currentview = 'Favorites';
+                            App.vent.trigger('favorites:list', []);
                             $('#filterbar-favorites').addClass('active');
                             break;
-                        case 'favorites':
+                        case 'Favorites':
                             App.currentview = 'anime';
                             App.vent.trigger(App.currentview + ':list', []);
                             $('.source.animeTabShow').addClass('active');
@@ -222,8 +222,8 @@
                         $('.source.animeTabShow').addClass('active');
                         break;
                     case 'ctrl+4':
-                        App.currentview = 'favorites';
-                        App.vent.trigger(App.currentview + ':list', []);
+                        App.currentview = 'Favorites';
+                        App.vent.trigger('favorites:list', []);
                         $('#filterbar-favorites').addClass('active');
                         break;
                     }

--- a/src/app/lib/views/browser/list.js
+++ b/src/app/lib/views/browser/list.js
@@ -151,57 +151,82 @@
 
             Mousetrap.bind(['tab', 'shift+tab'], function (e, combo) {
                 if ((App.PlayerView === undefined || App.PlayerView.isDestroyed) && $('#about-container').children().length <= 0 && $('#player').children().length <= 0) {
+                    App.vent.trigger('torrentCollection:close');
+                    App.vent.trigger('seedbox:close');
                     if (combo === 'tab') {
                         switch (App.currentview) {
                         case 'movies':
                             App.currentview = 'shows';
+                            App.vent.trigger(App.currentview + ':list', []);
+                            $('.source.tvshowTabShow').addClass('active');
                             break;
                         case 'shows':
                             App.currentview = 'anime';
+                            App.vent.trigger(App.currentview + ':list', []);
+                            $('.source.animeTabShow').addClass('active');
+                            break;
+                        case 'anime':
+                            App.currentview = 'favorites';
+                            App.vent.trigger(App.currentview + ':list', []);
+                            $('#filterbar-favorites').addClass('active');
                             break;
                         default:
                             App.currentview = 'movies';
+                            App.vent.trigger(App.currentview + ':list', []);
+                            $('.source.movieTabShow').addClass('active');
                         }
                     } else if (combo === 'shift+tab') {
                         switch (App.currentview) {
                         case 'movies':
+                            App.currentview = 'favorites';
+                            App.vent.trigger(App.currentview + ':list', []);
+                            $('#filterbar-favorites').addClass('active');
+                            break;
+                        case 'favorites':
                             App.currentview = 'anime';
+                            App.vent.trigger(App.currentview + ':list', []);
+                            $('.source.animeTabShow').addClass('active');
                             break;
                         case 'anime':
                             App.currentview = 'shows';
+                            App.vent.trigger(App.currentview + ':list', []);
+                            $('.source.tvshowTabShow').addClass('active');
                             break;
                         default:
                             App.currentview = 'movies';
+                            App.vent.trigger(App.currentview + ':list', []);
+                            $('.source.movieTabShow').addClass('active');
                         }
                     }
-
-                    App.vent.trigger('torrentCollection:close');
-                    App.vent.trigger('seedbox:close');
-                    App.vent.trigger(App.currentview + ':list', []);
-                    $('.filter-bar').find('.active').removeClass('active');
-                    $('.source.show' + App.currentview.charAt(0).toUpperCase() + App.currentview.slice(1)).addClass('active');
                 }
             });
 
-            Mousetrap.bind(['ctrl+1', 'ctrl+2', 'ctrl+3'], function (e, combo) {
+            Mousetrap.bind(['ctrl+1', 'ctrl+2', 'ctrl+3', 'ctrl+4'], function (e, combo) {
                 if ((App.PlayerView === undefined || App.PlayerView.isDestroyed) && $('#about-container').children().length <= 0 && $('#player').children().length <= 0) {
+                    App.vent.trigger('torrentCollection:close');
+                    App.vent.trigger('seedbox:close');
                     switch (combo) {
                     case 'ctrl+1':
                         App.currentview = 'movies';
+                        App.vent.trigger(App.currentview + ':list', []);
+                        $('.source.movieTabShow').addClass('active');
                         break;
                     case 'ctrl+2':
                         App.currentview = 'shows';
+                        App.vent.trigger(App.currentview + ':list', []);
+                        $('.source.tvshowTabShow').addClass('active');
                         break;
                     case 'ctrl+3':
                         App.currentview = 'anime';
+                        App.vent.trigger(App.currentview + ':list', []);
+                        $('.source.animeTabShow').addClass('active');
+                        break;
+                    case 'ctrl+4':
+                        App.currentview = 'favorites';
+                        App.vent.trigger(App.currentview + ':list', []);
+                        $('#filterbar-favorites').addClass('active');
                         break;
                     }
-
-                    App.vent.trigger('torrentCollection:close');
-                    App.vent.trigger('seedbox:close');
-                    App.vent.trigger(App.currentview + ':list', []);
-                    $('.filter-bar').find('.active').removeClass('active');
-                    $('.source.show' + App.currentview.charAt(0).toUpperCase() + App.currentview.slice(1)).addClass('active');
                 }
             });
 

--- a/src/app/lib/views/browser/list.js
+++ b/src/app/lib/views/browser/list.js
@@ -161,10 +161,17 @@
                             $('.source.tvshowTabShow').addClass('active');
                             break;
                         case 'shows':
-                            App.currentview = 'anime';
-                            App.vent.trigger(App.currentview + ':list', []);
-                            $('.source.animeTabShow').addClass('active');
-                            break;
+                            if (!Settings.animeTabDisable) {
+                                App.currentview = 'anime';
+                                App.vent.trigger(App.currentview + ':list', []);
+                                $('.source.animeTabShow').addClass('active');
+                                break;
+                            } else {
+                                App.currentview = 'Favorites';
+                                App.vent.trigger('favorites:list', []);
+                                $('#filterbar-favorites').addClass('active');
+                                break;
+                            }
                         case 'anime':
                             App.currentview = 'Favorites';
                             App.vent.trigger('favorites:list', []);
@@ -183,10 +190,17 @@
                             $('#filterbar-favorites').addClass('active');
                             break;
                         case 'Favorites':
-                            App.currentview = 'anime';
-                            App.vent.trigger(App.currentview + ':list', []);
-                            $('.source.animeTabShow').addClass('active');
-                            break;
+                            if (!Settings.animeTabDisable) {
+                                App.currentview = 'anime';
+                                App.vent.trigger(App.currentview + ':list', []);
+                                $('.source.animeTabShow').addClass('active');
+                                break;
+                            } else {
+                                App.currentview = 'shows';
+                                App.vent.trigger(App.currentview + ':list', []);
+                                $('.source.tvshowTabShow').addClass('active');
+                                break;	
+                            }
                         case 'anime':
                             App.currentview = 'shows';
                             App.vent.trigger(App.currentview + ':list', []);
@@ -217,15 +231,24 @@
                         $('.source.tvshowTabShow').addClass('active');
                         break;
                     case 'ctrl+3':
-                        App.currentview = 'anime';
-                        App.vent.trigger(App.currentview + ':list', []);
-                        $('.source.animeTabShow').addClass('active');
-                        break;
+                        if (!Settings.animeTabDisable) {
+                            App.currentview = 'anime';
+                            App.vent.trigger(App.currentview + ':list', []);
+                            $('.source.animeTabShow').addClass('active');
+                            break;
+                        } else {
+                            App.currentview = 'Favorites';
+                            App.vent.trigger('favorites:list', []);
+                            $('#filterbar-favorites').addClass('active');
+                            break;
+                        }
                     case 'ctrl+4':
-                        App.currentview = 'Favorites';
-                        App.vent.trigger('favorites:list', []);
-                        $('#filterbar-favorites').addClass('active');
-                        break;
+                        if (!Settings.animeTabDisable) {
+                            App.currentview = 'Favorites';
+                            App.vent.trigger('favorites:list', []);
+                            $('#filterbar-favorites').addClass('active');
+                            break;
+                        }
                     }
                 }
             });

--- a/src/app/lib/views/settings_container.js
+++ b/src/app/lib/views/settings_container.js
@@ -250,7 +250,6 @@
                 case 'subtitles_bold':
                 case 'rememberFilters':
                 case 'animeTabDisable':
-                case 'indieTabDisable':
                     value = field.is(':checked');
                     break;
                 case 'httpApiEnabled':
@@ -372,16 +371,6 @@
                         animeTab.css('display', 'block');
                     } else {
                         animeTab.css('display', 'none');
-                        App.vent.trigger('movies:list');
-                        App.vent.trigger('settings:show');
-                    }
-                    break;
-                case 'indieTabDisable':
-                    var indieTab = $('.indieTabShow');
-                    if (indieTab.css('display') === 'none') {
-                        indieTab.css('display', 'block');
-                    } else {
-                        indieTab.css('display', 'none');
                         App.vent.trigger('movies:list');
                         App.vent.trigger('settings:show');
                     }

--- a/src/app/settings.js
+++ b/src/app/settings.js
@@ -144,6 +144,7 @@ Settings.hideSeasons = true;
 Settings.startScreen = 'Movies';
 Settings.lastTab = '';
 Settings.rememberFilters = false;
+Settings.animeTabDisable = false;
 
 // Quality
 Settings.shows_default_quality = '720p';

--- a/src/app/templates/browser/filter-bar.tpl
+++ b/src/app/templates/browser/filter-bar.tpl
@@ -81,14 +81,14 @@
         <i id="filterbar-torrent-collection" class="fa fa-folder-open torrent-collection tooltipped" data-toggle="tooltip" data-placement="bottom" title="<%= i18n.__("Torrent Collection") %>"></i>
     </li>
 
-    <!-- About -->
-    <li>
-        <i id="filterbar-about" class="fa fa-info-circle about tooltipped" data-toggle="tooltip" data-placement="bottom" title="<%= i18n.__("About") %>"></i>
-    </li>
-
     <!-- Seedbox -->
     <li>
         <i id="filterbar-seedbox" class="fa fa-download about tooltipped" data-toggle="tooltip" data-placement="bottom" title="<%= i18n.__("Seedbox") %>"></i>
+    </li>
+
+    <!-- About -->
+    <li>
+        <i id="filterbar-about" class="fa fa-info-circle about tooltipped" data-toggle="tooltip" data-placement="bottom" title="<%= i18n.__("About") %>"></i>
     </li>
 
     <!-- Settings -->

--- a/src/app/templates/settings-container.tpl
+++ b/src/app/templates/settings-container.tpl
@@ -92,7 +92,7 @@
                 <div class="dropdown start-screen">
                     <p><%= i18n.__("Start Screen") %></p>
                         <%
-                            var arr_screens = ["Movies","TV Series","Anime","Indie","Favorites", "Watchlist", "Last Open"];
+                            var arr_screens = ["Movies","TV Series","Anime","Favorites","Watchlist","Last Open"];
 
                             var selct_start_screen = "";
                             for(var key in arr_screens) {
@@ -120,10 +120,6 @@
             <span class="advanced">
                 <input class="settings-checkbox" name="animeTabDisable" id="animeTabDisable" type="checkbox" <%=(Settings.animeTabDisable ? "checked='checked'":"")%>>
                 <label class="settings-label" for="animeTabDisable"><%= i18n.__("Disable Anime Tab") %></label>
-            </span>
-            <span class="advanced">
-                <input class="settings-checkbox" name="indieTabDisable" id="indieTabDisable" type="checkbox" <%=(Settings.indieTabDisable ? "checked='checked'":"")%>>
-                <label class="settings-label" for="indieTabDisable"><%= i18n.__("Disable Indie Tab") %></label>
             </span>
 
             <span class="advanced">


### PR DESCRIPTION
* Fix weird behavior when Favorites tab is clicked again while already being selected/active

* Change Favorites 'TV' filter to 'Series' so its the same as the tab name

* Fix tabulation (ctrl+1-4 and tab/shift+tab, included the Favorites tab, fixed the selected/active indicator and added a condition for when the anime tab is set to disabled)

* Remove 'Disable Indie Tab' remnants from the settings page (everything else about Indie should be removed more carefully so it doesnt create any issues, but at least now this obsolete feature&option isnt visible to users)

* Fix 'About' button's filter bar position (moved to the left of the 'Settings' button instead of the seedbox being between them which felt out of place)

* Add 'Settings.animeTabDisable = false' default value in settings.js