### PR TITLE
Bringing back Black & Red theme

### DIFF
--- a/src/app/styl/Official_-_Dark_theme.styl
+++ b/src/app/styl/Official_-_Dark_theme.styl
@@ -6,7 +6,7 @@
     $MainFontBold = 'Open Sans Bold'
     $AlternateFont = sans-serif
     $ButtonFont = 'Open Sans Semibold'
-
+    
 //Main app
     $BgColor1 = #17181b
     $BgColor2 = #212225

--- a/src/app/styl/Sebastiaans_-_Black_&_Red_theme.styl
+++ b/src/app/styl/Sebastiaans_-_Black_&_Red_theme.styl
@@ -75,7 +75,7 @@
 
 //Checkbox
     $CheckboxBg = #545454
-    $CheckboxCheck = #4bfff4
+    $CheckboxCheck = RedD
 
 //Posters
     $PosterRadius = 4px

--- a/src/app/styl/Sebastiaans_-_Black_&_Red_theme.styl
+++ b/src/app/styl/Sebastiaans_-_Black_&_Red_theme.styl
@@ -103,7 +103,7 @@
     $ShowWatchedIcon_hover = rgba(#fff,0.4)
     $ShowWatchedIcon_true = #fff
 
-    $QualitySelectorBg = rgba(43, 110, 210, 0.84)
+    $QualitySelectorBg = $ButtonBg
     $QualitySelectorText = $ButtonText
 
 //File selector

--- a/src/app/styl/Sebastiaans_-_Black_&_Red_theme.styl
+++ b/src/app/styl/Sebastiaans_-_Black_&_Red_theme.styl
@@ -1,0 +1,156 @@
+// THEME: BLACK & RED
+
+//Color variables: black & red
+    Black = #070707
+    RedL = #F31616
+    RedM = #E32020
+    RedD = #D40000
+
+//Fonts
+    $Font = 'Open Sans'
+    $MainFont = 'Open Sans Semibold'
+    $MainFontBold = 'Open Sans Bold'
+    $AlternateFont = sans-serif
+    $ButtonFont = 'Open Sans Semibold'
+    
+//Main app
+    $BgColor1 = Black
+    $BgColor2 = lighten(Black,5%)
+
+    $Text1 = #fff 
+    $Text2 = #C9C9C9
+    $Text3 = #939597
+    $Text4 = #fff
+    $TextError = #797979
+
+    $CloseButton = #fff
+    $CloseButtonHover = RedL
+
+    $SpinnerColor1 = RedM
+    $SpinnerColor2 = RedD
+
+    $ScrollBarBg = #30333c
+    $ScrollBarThumb = RedM
+    $ScrollBarThumbHover = RedD
+
+//Top Bar
+    $TitleBarBg = Black  
+    $TitleBarText = #fff
+    $FullScreenButton = #999
+    $FullScreenButtonHover = RedL
+
+    $FilterBarBg = Black  
+    $FilterBarText = #e9e9e9
+    $FilterBarTextHover = #fff
+    $FilterBarActive = RedL
+
+    $SearchBoxBg = #191818
+
+    $DropDownBg = rgba(Black,0.9)
+    $DropDownBgHover = rgba(RedL,0.15)
+    $DropDownTextHover = #fff
+    $DropDownText = #d9d9d9
+    $DropDownOpacity = 0.97
+
+    $FilterBarIcon = $Text1
+    $FilterBarIconHover = RedD
+    $FilterBarIcon-PosterWidth = #bababa
+
+    $TopBarShadow = 0px 6px 8px -4px rgba(0, 0, 0, .9);
+
+//Buttons
+    $ButtonBg = RedL
+    $ButtonBgHover = RedD
+    $ButtonBgActive = RedD
+
+    $ButtonBgDisabled = #737577
+
+    $ButtonBgOk = #27AE60
+    $ButtonBgWarning = #F15153
+
+    $ButtonText = #fff
+    $ButtonTextHover = #fff
+
+    $ButtonRadius = 3px
+
+//Checkbox
+    $CheckboxBg = #545454
+    $CheckboxCheck = #4bfff4
+
+//Posters
+    $PosterRadius = 4px
+    $PosterHoverBorder = $ButtonBgActive
+    $PosterHoverOverlay = rgba(23, 24, 27, 0.6)
+    $PosterShadow = 0px 0px 10px
+
+//TV Series
+    $ShowBgColor1 = $BgColor1
+    $ShowBgColor2 = $BgColor2
+
+    $EpisodeDetailsBg = $BgColor1
+
+    $ShowText1 = $Text1
+    $ShowText2 = $Text2
+
+    $SaisonListText = $Text1
+    $EpisodeListText = $Text2
+
+    $EpisodeSelectorBg = darken(#e3bd0c,2%)
+    $EpisodeSelectorHover = #26272d
+    $EpisodeSelectorText = $ButtonText
+
+    $ShowWatchedIcon_false = rgba(#fff,0.2)
+    $ShowWatchedIcon_hover = rgba(#fff,0.4)
+    $ShowWatchedIcon_true = #fff
+
+    $QualitySelectorBg = rgba(43, 110, 210, 0.84)
+    $QualitySelectorText = $ButtonText
+
+//File selector
+    $FileSelectorText = #eee
+    $FileSelectorBg = rgba(255, 255, 255, 0.05)
+    $FileSelectorShadow = rgba(0, 0, 0, 0.67)
+
+//Settings
+    $SettingsCategoriesText = RedD
+    $SettingsSeparator = #333
+
+    $InputBoxBg = #232324
+    $InputBoxText = $Text2
+
+    $SettingsText1 = $Text2
+    $SettingsText2 = $Text3
+
+    $SettingsButtonText = $ButtonText
+    $SettingsButtonTextHover = $ButtonText
+
+// Notifications
+    $NotificationText = #fff
+    $NotificationInfo = #3498DB
+    $NotificationSuccess = #27AE60
+    $NotificationWarning = #dbb756
+    $NotificationOrange = #f07f53
+    $NotificationError = #f15153
+    $NotificationBorderColor = #000
+
+    $NotificationBtn = #000
+    $NotificationBtnText = #fff
+
+    $NotifAlertBg = #000
+    $NotifAlertText = #fff
+
+//Misc
+    $PngLogo = brightness(1.0)
+    $FavoriteColor = #df2d37
+    $PosterFavHover = RedD
+    $PosterFavSelected = RedD
+    $PosterWatchedHover = RedD
+    $FavoriteColor = #df2d37
+
+//Player
+    $PlayerColor = RedL
+
+
+// THEME: BLACK & RED - END
+
+@import 'views/app'


### PR DESCRIPTION
Because it's imo the most beautiful theme and 3rd parties themes are annoying to use since they were removed.
I will appreciate this one to be put back with official themes... and it's relatively trivial to maintain too.

It needed just little fixes for quality selector and checkboxes.

Screenshots:
![Screenshot_2020-08-06_13-53-42](https://user-images.githubusercontent.com/22459458/89529004-477f4c00-d7ec-11ea-926f-3f152da256a5.png)
![Screenshot_2020-08-06_13-34-26](https://user-images.githubusercontent.com/22459458/89527424-9a0b3900-d7e9-11ea-8846-1d4f572f0cca.png)
![Screenshot_2020-08-06_13-35-12](https://user-images.githubusercontent.com/22459458/89527474-af806300-d7e9-11ea-9a87-eaa11b890a13.png)
![Screenshot_2020-08-06_13-41-47](https://user-images.githubusercontent.com/22459458/89528095-c07da400-d7ea-11ea-811f-e68de2ec4fd3.png)
![Screenshot_2020-08-06_13-42-46](https://user-images.githubusercontent.com/22459458/89528113-c83d4880-d7ea-11ea-9cef-2adfb2a7a7c4.png)



