### PR TITLE
Seedbox torrent reliability

### DIFF
--- a/src/app/app.js
+++ b/src/app/app.js
@@ -101,6 +101,8 @@ App.WebTorrent = new WebTorrent({
   dht: true
 });
 
+App.plugins = {};
+
 fs.readFile('./.git.json', 'utf8', function (err, json) {
   if (!err) {
     App.git = JSON.parse(json);

--- a/src/app/common.js
+++ b/src/app/common.js
@@ -295,3 +295,5 @@ Common.Promises = {
 		return Promise.all(wrappedPromises);
 	}
 };
+
+Common.getTorrentUri = torrent => torrent.magnet || torrent.url || torrent;

--- a/src/app/index.html
+++ b/src/app/index.html
@@ -85,6 +85,9 @@
     <script src="lib/subtitle/server.js"></script>
     <script src="lib/streamer.js"></script>
 
+    <!-- App Plugins -->
+    <script src="lib/plugins/media-name.js"></script>
+
     <!-- Backbone Models -->
     <script src="lib/models/filter.js"></script>
     <script src="lib/models/lang.js"></script>

--- a/src/app/lib/plugins/media-name.js
+++ b/src/app/lib/plugins/media-name.js
@@ -1,0 +1,99 @@
+((App) => {
+    const mediaNameSymbol = Symbol('torrentMediaName');
+
+    // If a value is in the cache for longer than a minute, it is
+    // assumed to be invalid -- perhaps there was some error in
+    // initializing the download. We generally expect operations
+    // to be performed on the order of milliseconds, but we're
+    // giving a lot of leeway here just for the sake of resilience.
+    // We may also never consume if the torrent is ready immediately.
+    const maxTimeInCacheMs = 60 * 1000;
+
+    /**
+     * When torrents are added, we don't know their title until they tell us they are "ready".
+     * However, some torrents are never ready, and even if they are ready, it may take
+     * anywhere from a few seconds for a torrent with good health up to minutes for one with
+     * poor health.
+     * This plugin helps provide the name of the source media until we know the actual title
+     * of the torrent once it is ready.
+     * To reduce memory usage, all media names are only able to be "consumed" rather than read,
+     * meaning they can only be read once before they must be re-inserted into this cache.
+     */
+    class MediaNamePlugin {
+        constructor() {
+            this._infoHashToMediaName = new Map();
+            this._infoHashToInsertTime = new Map();
+            // the timeout is arbitrary and can be changed without consequence, but it shouldn't be too short so that
+            // we avoid iterating over all the entries too often.
+            this._cleanupTask = setInterval(() => this._clean(), maxTimeInCacheMs);
+        }
+
+        _remove(infoHash) {
+            this._infoHashToInsertTime.delete(infoHash);
+            this._infoHashToMediaName.delete(infoHash);
+        }
+
+        _clean() {
+            const now = Date.now();
+            for (const [infoHash, insertTime] of this._infoHashToInsertTime) {
+                if (now - insertTime >= maxTimeInCacheMs) {
+                    this._remove(infoHash);
+                }
+            }
+        }
+
+        /**
+         * Given an infoHash, gets the cached name of that torrent's
+         * source media, and deletes it from the cache if it exists.
+         * @param infoHash - The torrent's infoHash
+         * @returns {string}
+         */
+        _consumeMediaName(infoHash) {
+            const mediaName = this._infoHashToMediaName.get(infoHash);
+            this._remove(infoHash);
+            return mediaName;
+        }
+
+        /**
+         * Sets the original media name to be consumed once downloading begins
+         * @param infoHash - The torrent to be downloaded
+         * @param mediaName - The name of the source media for this torrent
+         */
+        setMediaName(infoHash, mediaName) {
+            this._infoHashToMediaName.set(infoHash, mediaName);
+            this._infoHashToInsertTime.set(infoHash, Date.now());
+        }
+
+        /**
+         * Get the name of a given torrent. This will use torrent.name if available,
+         * or the cached media name otherwise.
+         * @param torrent
+         * @returns {string}
+         */
+        getMediaName(torrent) {
+            console.log('getting media name for', torrent);
+            console.log(this);
+            if (torrent.name) {
+                return torrent.name;
+            }
+
+            if (torrent[mediaNameSymbol]) {
+                return torrent[mediaNameSymbol];
+            }
+
+            const mediaName = this._consumeMediaName(torrent.infoHash);
+            if (mediaName) {
+                torrent[mediaNameSymbol] = mediaName;
+                return mediaName;
+            }
+
+            return i18n.__('Unknown torrent');
+        }
+    }
+
+    /**
+     * @namespace {App}
+     * @type {MediaNamePlugin}
+     */
+    App.plugins.mediaName = new MediaNamePlugin();
+})(window.App);

--- a/src/app/lib/streamer.js
+++ b/src/app/lib/streamer.js
@@ -88,17 +88,22 @@
             }.bind(this)).then(this.waitForBuffer.bind(this)).catch(this.handleErrors.bind(this));
         },
 
-        download: function(torrent) {
+        download: function(torrent, mediaName = '') {
             // if webtorrent is created/running, we stop/destroy it
             if (App.WebTorrent.destroyed) {
                 this.stop();
             }
 
             // handles magnet and hosted torrents
-            var uri = torrent.magnet || torrent.url || torrent;
+            const uri = Common.getTorrentUri(torrent);
             const parseTorrent = require('parse-torrent');
             var infoHash = '';
             try { infoHash = parseTorrent(uri).infoHash; } catch (err) {}
+
+            if (mediaName) {
+                App.plugins.mediaName.setMediaName(infoHash, mediaName);
+            }
+
             App.WebTorrent.add(uri, {
               path      : App.settings.tmpLocation + '/' + infoHash,
               maxConns  : 5,

--- a/src/app/lib/views/play_control.js
+++ b/src/app/lib/views/play_control.js
@@ -204,7 +204,7 @@
         lang: this.audio_selected
       };
 
-      var torrent = providers.torrent.resolveStream
+      const torrent = providers.torrent.resolveStream
         ? providers.torrent.resolveStream(
             defaultTorrent,
             filters,
@@ -212,7 +212,7 @@
           )
         : defaultTorrent;
 
-      App.vent.trigger('stream:download', torrent);
+      App.vent.trigger('stream:download', torrent, this.model.get('title') /*mediaName*/);
       App.previousview = App.currentview;
       App.currentview = 'Seedbox';
       App.vent.trigger('seedbox:show');

--- a/src/app/lib/views/seedbox.js
+++ b/src/app/lib/views/seedbox.js
@@ -127,7 +127,7 @@
 				`<li class="${className}" id="${torrent.infoHash}" data-season="" data-episode="">
                 <a href="#" class="episodeData">
                     <span>1</span>
-                    <div id="title-${torrent.infoHash}">${torrent.name || i18n.__('Unknown torrent')}</div>
+                    <div id="title-${torrent.infoHash}">${App.plugins.mediaName.getMediaName(torrent)}</div>
                 </a>
 
                 <i class="fa fa-trash-alt watched trash-torrent" id="trash-${torrent.infoHash}"></i>
@@ -282,16 +282,18 @@
 				this.updateHealth(torrent);
 			}
 
+			const $fileList = $('.torrents-info > ul.file-list');
+
+			$fileList.empty();
 			$('.seedbox-infos-title').text(torrent.name);
 			$('.seedbox-downloaded').text(' ' + formatBytes(torrent.downloaded));
 			$('.seedbox-uploaded').text(' ' + formatBytes(torrent.uploaded));
 			$('.seedbox-infos-date').text(stats.ctime);
-			$('.torrents-info > ul.file-list').empty();
 			$('.progress-bar').css('width', (torrent.progress * 100).toFixed(2) + '%');
 			$('.progress-percentage>span').text((torrent.progress * 100).toFixed(2) + '%');
 
 			for (const file of torrent.files) {
-				$('.torrents-info>ul.file-list').append(
+				$fileList.append(
 					`<li class="file-item">
 							<a>${file.name}</a>
 							<i class="fa fa-folder-open item-delete tooltipped" data-toggle="tooltip" data-placement="left" title=""></i>

--- a/src/app/lib/views/show_detail.js
+++ b/src/app/lib/views/show_detail.js
@@ -504,8 +504,8 @@
         },
 
         downloadTorrent: function(e) {
-          var torrent = $(e.currentTarget).attr('data-torrent');
-          App.vent.trigger('stream:download', torrent);
+          const torrent = $(e.currentTarget).attr('data-torrent');
+          App.vent.trigger('stream:download', torrent, this.model.get('title') /*mediaName*/);
           App.previousview = App.currentview;
           App.currentview = 'Seedbox';
           App.vent.trigger('seedbox:show');

--- a/src/app/styl/views/seedbox.styl
+++ b/src/app/styl/views/seedbox.styl
@@ -126,6 +126,9 @@
               .seedbox-torrent-list ul li.active a
                   color: $EpisodeSelectorText
 
+              .seedbox-torrent-list ul li.error
+                  background: $NotificationError
+
               .notorrents-info
                   display block
                   height 100%


### PR DESCRIPTION
via #1605 , there are issues in seedbox when torrents can't be resolved (to test for yourself, sort by least popularity, and try downloading anything).

To fix this, and hopefully resolve some of the seedbox issues for now (there will likely be more, but that's just because seedbox needs some more refactors, and hopefully not due to my changes), I have done the following:
- Seedbox torrents always show up on the list immediately now, rather than once the torrent is ready. This prevents torrents that are never ready from not appearing.
	- Once a torrent is ready, listeners like upload/download are added. Therefore, a torrent that is never ready will always be at 0% progress.
- A new `MediaNamePlugin` has been added (I've also added the field `App.plugins`) which stores the source media name temporarily while the torrent is being transferred from any page through the streamer into the seedbox. Because we reconstruct the torrent object, there is no straightforward way to set the data in any place that all pages can read it -- but this solution allows us to cache media names by their infoHash, and then retrieve them on the torrent page. This results in torrents immediately having their name rather than having to put "Unknown torrent" until ready.
- When a torrent receives a fatal "error" event, it is paused and the list item turns red (or whatever the error background is for that theme).

Overall, this makes the seedbox UI feel better for torrents that have good health due to the change to immediately show source media name. In addition, torrents that are "doomed" will now show on the screen, so users know they aren't lost. 

One outstanding task is now to fix memory leaks, which is an issue that was there before I even started touching this file. We are adding listeners for upload, download, etc. but never removing them -- and that's obviously bad. Each time the page is rendered, we're adding new listeners.