### PR TITLE
Fix lang dropdown margins & item title tooltip

### DIFF
--- a/src/app/lib/views/browser/item.js
+++ b/src/app/lib/views/browser/item.js
@@ -39,6 +39,13 @@
             this.loadImage();
             this.setCoverStates();
             this.setTooltips();
+
+            this.$('.tooltipped').tooltip({
+                delay: {
+                    'show': 800,
+                    'hide': 100
+                }
+            });
         },
 
         hoverItem: function (e) {

--- a/src/app/lib/views/browser/item.js
+++ b/src/app/lib/views/browser/item.js
@@ -40,7 +40,7 @@
             this.setCoverStates();
             this.setTooltips();
 
-            this.$('.tooltipped').tooltip({
+            $('.tooltipped').tooltip({
                 delay: {
                     'show': 800,
                     'hide': 100

--- a/src/app/styl/views/dropdowns.styl
+++ b/src/app/styl/views/dropdowns.styl
@@ -3,7 +3,6 @@
   align-items: center
   cursor: pointer
   height: 35px
-  margin-right: 15px
   padding: 0 15px
   color: #fff
   font-family: $MainFont
@@ -25,6 +24,7 @@
   display: flex
   flex-wrap: wrap
   max-width: 100%
+  margin-left: 5px
 
 .flag
   margin: 3px

--- a/src/app/styl/views/movie_detail.styl
+++ b/src/app/styl/views/movie_detail.styl
@@ -251,7 +251,7 @@
 
             height: 70px
             line-height: 35px
-            margin: 10px 10px 6px 16px
+            margin: 10px 25px 6px 16px
 
             .setup-container
               display: flex

--- a/src/app/templates/browser/item.tpl
+++ b/src/app/templates/browser/item.tpl
@@ -30,7 +30,7 @@
     </div>
 </div>
 
-<p class="title" title="<%= title %>"><%= title %></p>
+<p class="title tooltipped" <% if(title.length > 20){ %> title="<%= title %>" data-toggle="tooltip" data-placement="auto bottom" <% } %> ><%= title %></p>
 <p class="year">
     <% if (typeof year !== 'undefined') {%>
         <%= year %>


### PR DESCRIPTION
* Lang dropdown margins fix
[Before](https://user-images.githubusercontent.com/38388670/89605915-6971e080-d877-11ea-94e2-4404867e366f.jpg) / [After](https://user-images.githubusercontent.com/38388670/89605926-74c50c00-d877-11ea-8580-1906e14e1fd3.jpg)

* Fix item title tooltip
Styled the (already existing) tooltip when you hover an item title in the movies/series/anime list and made it appear only if its a long title and its getting cropped