### PR TITLE
yarn commands, yarn.lock, gulp dist example and README update 

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,19 +29,19 @@ cask 'popcorn-time'
 
 #### Linux - Debian/Ubuntu based distros (tested on ubuntu 18.04):
 
-* Install unzip && dependencies (they should not be always required but some users needed them to make Popcorn Time working) :
+* Install unzip && dependencies (they should not be always required but some users needed them to make Popcorn Time working) :  
 `sudo apt update && sudo apt install unzip libcanberra-gtk-module libgconf-2-4 libatomic1`
-* Create popcorn-time folder in /opt/ :
+* Create popcorn-time folder in /opt/ :  
 `sudo mkdir /opt/popcorn-time`
-* Download Popcorn Time archive :
+* Download Popcorn Time archive :  
 `wget https://get.popcorntime.app/repo/build/Popcorn-Time-0.4.4-linux64.zip`
-* Extract the zip in /opt/popcorn-time :
+* Extract the zip in /opt/popcorn-time :  
 `sudo unzip Popcorn-Time-0.4.4-linux64.zip -d /opt/popcorn-time`
-* Create symlink of Popcorn-Time in /usr/bin :
+* Create symlink of Popcorn-Time in /usr/bin :  
 `sudo ln -sf /opt/popcorn-time/Popcorn-Time /usr/bin/popcorn-time`
-* Create .desktop file (so the launcher) :
+* Create .desktop file (so the launcher) :  
 `sudo nano /usr/share/applications/popcorntime.desktop`
-* and copy paste the following text in the editor and save
+* and copy paste the following text in the editor and save  
 
 ```desktop
 [Desktop Entry]
@@ -69,7 +69,7 @@ The [master](https://github.com/popcorn-official/popcorn-desktop) branch which c
 
 1. `yarn start`
 
-If you encounter trouble with the above method, you can try:
+If you encounter trouble with the above method, you can try:  
 
 1. `yarn config set yarn-offline-mirror ./node_modules/`
 2. `yarn install --ignore-engines`

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ Full instructions & troubleshooting tips can be found in the [Contributing Guide
 - `all`
 
 
-Redistribuable packages are saved into `/build` subfolder.
+Redistribuable packages are saved into `build/` subfolder.
 
 
 <a name="community"></a>

--- a/README.md
+++ b/README.md
@@ -27,21 +27,21 @@ tap repo, "https://github.com/#{repo}.git"
 cask 'popcorn-time'
 ~~~
 
-#### Linux - Debian/Ubuntu based distros (tested on ubuntu 18.04):  
+#### Linux - Debian/Ubuntu based distros (tested on ubuntu 18.04):
 
-* Install unzip && dependencies (they should not be always required but some users needed them to make Popcorn Time working) :  
+* Install unzip && dependencies (they should not be always required but some users needed them to make Popcorn Time working) :
 `sudo apt update && sudo apt install unzip libcanberra-gtk-module libgconf-2-4 libatomic1`
-* Create popcorn-time folder in /opt/ :  
+* Create popcorn-time folder in /opt/ :
 `sudo mkdir /opt/popcorn-time`
-* Download Popcorn Time archive :  
+* Download Popcorn Time archive :
 `wget https://get.popcorntime.app/repo/build/Popcorn-Time-0.4.4-linux64.zip`
-* Extract the zip in /opt/popcorn-time :  
+* Extract the zip in /opt/popcorn-time :
 `sudo unzip Popcorn-Time-0.4.4-linux64.zip -d /opt/popcorn-time`
-* Create symlink of Popcorn-Time in /usr/bin :  
+* Create symlink of Popcorn-Time in /usr/bin :
 `sudo ln -sf /opt/popcorn-time/Popcorn-Time /usr/bin/popcorn-time`
-* Create .desktop file (so the launcher) :  
+* Create .desktop file (so the launcher) :
 `sudo nano /usr/share/applications/popcorntime.desktop`
-* and copy paste the following text in the editor and save  
+* and copy paste the following text in the editor and save
 
 ```desktop
 [Desktop Entry]
@@ -79,6 +79,26 @@ If you encounter trouble with the above method, you can try:
 Optionally, you may simply run `./make_popcorn.sh` if you are on a linux or mac based operating system.
 
 Full instructions & troubleshooting tips can be found in the [Contributing Guide](CONTRIBUTING.md#contributing-to-popcorn-time).
+
+
+#### Building redistribuable packages/installers:
+
+1. `yarn config set yarn-offline-mirror ./node_modules/`
+2. `yarn install --ignore-engines`
+2. `yarn dist --platforms=<platform>`
+
+`<platform>` can be one or more of the folowing values (separated by a comma `,`):
+
+- `win64`
+- `win32`
+- `linux64`
+- `linux32`
+- `osx64`
+- `all`
+
+
+Redistribuable packages are saved into `/build` subfolder.
+
 
 <a name="community"></a>
 ## Community

--- a/README.md
+++ b/README.md
@@ -31,17 +31,17 @@ cask 'popcorn-time'
 
 * Install unzip && dependencies (they should not be always required but some users needed them to make Popcorn Time working) :
 `sudo apt update && sudo apt install unzip libcanberra-gtk-module libgconf-2-4 libatomic1`
-* Create popcorn-time folder in /opt/ :
+* Create popcorn-time folder in /opt/ :  
 `sudo mkdir /opt/popcorn-time`
-* Download Popcorn Time archive :
+* Download Popcorn Time archive :  
 `wget https://get.popcorntime.app/repo/build/Popcorn-Time-0.4.4-linux64.zip`
-* Extract the zip in /opt/popcorn-time :
+* Extract the zip in /opt/popcorn-time :  
 `sudo unzip Popcorn-Time-0.4.4-linux64.zip -d /opt/popcorn-time`
-* Create symlink of Popcorn-Time in /usr/bin :
+* Create symlink of Popcorn-Time in /usr/bin :  
 `sudo ln -sf /opt/popcorn-time/Popcorn-Time /usr/bin/popcorn-time`
-* Create .desktop file (so the launcher) :
+* Create .desktop file (so the launcher) :  
 `sudo nano /usr/share/applications/popcorntime.desktop`
-* and copy paste the following text in the editor and save
+* and copy paste the following text in the editor and save  
 
 ```desktop
 [Desktop Entry]
@@ -69,7 +69,7 @@ The [master](https://github.com/popcorn-official/popcorn-desktop) branch which c
 
 1. `yarn start`
 
-If you encounter trouble with the above method, you can try:
+If you encounter trouble with the above method, you can try:  
 
 1. `yarn config set yarn-offline-mirror ./node_modules/`
 2. `yarn install --ignore-engines`

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -162,7 +162,8 @@ gulp.task('default', (done) => {
       '\nAvailable options:',
       ' --platforms=<platform>',
       '\tArguments: ' + availablePlatforms + ',all',
-      '\tExample:   `gulp build --platforms=all`',
+      '\tExample 1:   `gulp dist --platforms=all`',
+      '\tExample 2:   `gulp dist --platforms=win64,linux64`',
       '\nUse `gulp --tasks` to show the task dependency tree of gulpfile.js\n'
     ].join('\n')
   );

--- a/package.json
+++ b/package.json
@@ -14,9 +14,11 @@
   "version": "0.4.4",
   "releaseName": "Love in the Time of Corona",
   "scripts": {
-    "start": "gulp run",
     "build": "gulp build",
     "clean": "gulp clean",
+    "css": "gulp css",
+    "dist": "gulp dist",
+    "start": "gulp run",
     "test": "gulp test"
   },
   "chromium-args": "--remote-debugging-port=9222 --enable-node-worker",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2400,6 +2400,11 @@ first-chunk-stream@^1.0.0:
   resolved "https://registry.yarnpkg.com/first-chunk-stream/-/first-chunk-stream-1.0.0.tgz#59bfb50cd905f60d7c394cd3d9acaab4e6ad934e"
   integrity sha1-Wb+1DNkF9g18OUzT2ayqtOatk04=
 
+flag-icon-css@^3.5.0:
+  version "3.5.0"
+  resolved "https://registry.yarnpkg.com/flag-icon-css/-/flag-icon-css-3.5.0.tgz#430747d5cb91e60babf85494de99173c16dc7cf2"
+  integrity sha512-pgJnJLrtb0tcDgU1fzGaQXmR8h++nXvILJ+r5SmOXaaL/2pocunQo2a8TAXhjQnBpRLPtZ1KCz/TYpqeNuE2ew==
+
 flagged-respawn@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/flagged-respawn/-/flagged-respawn-1.0.1.tgz#e7de6f1279ddd9ca9aac8a5971d618606b3aab41"


### PR DESCRIPTION
So:

- adding yarn css and yarn dist commands
- updating yarn.lock to take flag-icon-css
- add another `gulp dist` example in gulpfile.js
- Update README to explain how to build redistributable packages of the app