### PR TITLE
Automatically select the default subtitle language & misc fixes

### DIFF
--- a/src/app/lib/views/lang_dropdown.js
+++ b/src/app/lib/views/lang_dropdown.js
@@ -43,6 +43,10 @@
             this.values = newLangs;
             this.render();
 
+            if ((Settings.subtitle_language !== 'none') && (Settings.subtitle_language in newLangs)) {
+                this.setLang(Settings.subtitle_language);
+            }
+
             $('.tooltipped').tooltip({
                 delay: {
                     'show': 800,

--- a/src/app/lib/views/lang_dropdown.js
+++ b/src/app/lib/views/lang_dropdown.js
@@ -42,6 +42,13 @@
             this.model.set('values', newLangs);
             this.values = newLangs;
             this.render();
+
+            $('.tooltipped').tooltip({
+                delay: {
+                    'show': 800,
+                    'hide': 100
+                }
+            });
         },
 
         setLang: function (value) {

--- a/src/app/lib/views/torrent_collection.js
+++ b/src/app/lib/views/torrent_collection.js
@@ -220,7 +220,7 @@
                         var rbg = torrentCollection.rbg;
                         rbg.search({
                             query: input.toLocaleLowerCase(),
-                            category: category.toLocaleLowerCase() === 'movies' ? 'movies' : 'tv',
+                            category: category.toLocaleLowerCase(),
                             sort: 'seeders',
                             verified: false
                         }).then(function (data) {

--- a/src/app/settings.js
+++ b/src/app/settings.js
@@ -154,7 +154,7 @@ Settings.movies_quality = 'all';
 
 // Subtitles
 Settings.subtitle_language = 'none';
-Settings.subtitle_size = '28px';
+Settings.subtitle_size = '38px';
 Settings.subtitle_color = '#ffffff';
 Settings.subtitle_decoration = 'Outline';
 Settings.subtitle_font = 'Arial';

--- a/src/app/templates/lang-dropdown.tpl
+++ b/src/app/templates/lang-dropdown.tpl
@@ -8,7 +8,7 @@
         <div class="flag-container">
             <% for(var lang in values){ %>
             <%   if(lang.indexOf('|')!==-1) continue; %>
-            <div class="flag-icon flag <%= lang %>" data-lang="<%= lang %>" title="<%= App.Localization.nativeName(lang) %>"></div>
+            <div class="flag-icon flag <%= lang %> tooltipped" data-toggle="tooltip" data-placement="top" data-lang="<%= lang %>" title="<%= App.Localization.nativeName(lang) %>"></div>
             <% } %>
         </div>
     </div>


### PR DESCRIPTION
* Automatically select the default subtitle language in movie detail if its available

* Style the lang dropdown tooltips

* Increase the default subtitle size from 28px to 38px (they were way too small, they are still visibly smaller than e.g VLC, especially when the video is 16:9 but I tried to be conservative..)

* Add RARBG missing categories (the module `torrentapi-wrapper2` needs a small update too, this edit will function as before until then)