### PR TITLE
Player UI and subtitle scaling fix

### DIFF
--- a/src/app/styl/views/videojs.styl
+++ b/src/app/styl/views/videojs.styl
@@ -30,7 +30,7 @@
         position: absolute;
         bottom: 0;
         left: 0;
-        background-color: linear-gradient(transparent, rgba(0,0,0,0.7));
+        background: linear-gradient(transparent, rgba(0,0,0,0.7));
     }
 
     .vjs-control-bar {

--- a/src/app/vendor/videojshooks.js
+++ b/src/app/vendor/videojshooks.js
@@ -88,9 +88,10 @@ vjs.TextTrack.prototype.load = function () {
         var subsParams = function () {
             var subtitles = $('.vjs-subtitles');
             var vjsTextTrack = $('.vjs-text-track');
+            var vjsTextTrackDsp = $('.vjs-text-track-display');
 
             vjsTextTrack.css('display', 'inline-block').drags();
-            vjsTextTrack.css('font-size', Settings.subtitle_size);
+            vjsTextTrackDsp.css('font-size', Settings.subtitle_size);
             if (win.isFullscreen) {
                 vjsTextTrack.css('font-size', '140%');
             }


### PR DESCRIPTION
* Player UI fix
(an extra `-color` in videojs.styl made the gradient background for the bottom video controls not show up)

* Subtitle scaling fix
(https://github.com/popcorn-official/popcorn-desktop/pull/1618/commits/05332818e6e768f7e8a1b543f592316caebac82f broke the subtitle scaling a bit which made the subtitles become tiny when fullscreen in/out, this fixes it)