### PR TITLE
Player UI and subtitle scaling fix

### DIFF
--- a/src/app/lib/views/player/player.js
+++ b/src/app/lib/views/player/player.js
@@ -12,8 +12,8 @@
             uploadSpeed: '.upload_speed_player',
             activePeers: '.active_peers_player',
             downloaded: '.downloaded_player',
-            pause: 'fas .fa-pause',
-            play: 'fas .fa-play'
+            pause: '.fa-pause',
+            play: '.fa-play'
         },
 
         events: {
@@ -304,10 +304,10 @@
                     this.firstPlay = false;
                     return;
                 }
-                this.ui.pause.hide().dequeue();
+                this.ui.pause.hide().dequeue().css('transform', 'scale(1)');
                 this.ui.play.appendTo('div#video_player');
-                this.ui.play.show().delay(1500).queue(function () {
-                    this.ui.play.hide().dequeue();
+                this.ui.play.fadeIn(10).css('transform', 'scale(1.5)').delay(190).queue(function () {
+                    this.ui.play.fadeOut(700).dequeue();
                 }.bind(this));
                 App.vent.trigger('player:play');
             }
@@ -320,10 +320,10 @@
                 this.wasSeek = true;
             } else {
                 this.wasSeek = false;
-                this.ui.play.hide().dequeue();
+                this.ui.play.hide().dequeue().css('transform', 'scale(1)');
                 this.ui.pause.appendTo('div#video_player');
-                this.ui.pause.show().delay(1500).queue(function () {
-                    this.ui.pause.hide().dequeue();
+                this.ui.pause.fadeIn(10).css('transform', 'scale(1.5)').delay(190).queue(function () {
+                    this.ui.pause.fadeOut(700).dequeue();
                 }.bind(this));
                 App.vent.trigger('player:pause');
                 this.sendToTrakt('pause');
@@ -901,6 +901,7 @@
             var v = this.player.volume();
             this.player.volume(v + i);
             App.vent.trigger('volumechange');
+            $('.vjs-overlay').css('opacity', '1');
         },
 
         toggleMute: function () {
@@ -954,14 +955,14 @@
                     $('.vjs-overlay').fadeOut('normal', function () {
                         $(this).remove();
                     });
-                }, 3000));
+                }, 1200));
             } else {
                 $(this.player.el()).append('<div class =\'vjs-overlay vjs-overlay-top-left\'>' + message + '</div>');
                 $.data(this, 'overlayTimer', setTimeout(function () {
                     $('.vjs-overlay').fadeOut('normal', function () {
                         $(this).remove();
                     });
-                }, 3000));
+                }, 1200));
             }
         },
 

--- a/src/app/lib/views/player/player.js
+++ b/src/app/lib/views/player/player.js
@@ -306,8 +306,8 @@
                 }
                 this.ui.pause.hide().dequeue().css('transform', 'scale(1)');
                 this.ui.play.appendTo('div#video_player');
-                this.ui.play.fadeIn(10).css('transform', 'scale(1.5)').delay(190).queue(function () {
-                    this.ui.play.fadeOut(700).dequeue();
+                this.ui.play.show().delay(10).queue(function () {
+                    this.ui.play.css('transform', 'scale(2)').fadeOut(400).dequeue();
                 }.bind(this));
                 App.vent.trigger('player:play');
             }
@@ -322,8 +322,8 @@
                 this.wasSeek = false;
                 this.ui.play.hide().dequeue().css('transform', 'scale(1)');
                 this.ui.pause.appendTo('div#video_player');
-                this.ui.pause.fadeIn(10).css('transform', 'scale(1.5)').delay(190).queue(function () {
-                    this.ui.pause.fadeOut(700).dequeue();
+                this.ui.pause.show().delay(10).queue(function () {
+                    this.ui.pause.css('transform', 'scale(2)').fadeOut(400).dequeue();
                 }.bind(this));
                 App.vent.trigger('player:pause');
                 this.sendToTrakt('pause');
@@ -374,7 +374,7 @@
             var that = this;
 
             // Double Click to toggle Fullscreen
-            $('#video_player').dblclick(function (event) {
+            $('#video_player, .state-info-player').dblclick(function (event) {
                 that.toggleFullscreen();
                 // Stop any mouseup events pausing video
                 event.preventDefault();

--- a/src/app/styl/views/player.styl
+++ b/src/app/styl/views/player.styl
@@ -48,13 +48,15 @@
     }
     .state-info-player {
         position: absolute
-        right: 90px
-        top: 110px
+        width: 100%
+        margin: auto
+        text-align: center
+        top: 45%
         font-size 50px
         color: rgba(255,255,255,.3)
         z-index: 23
         display: none
-        transition: all .1s
+        transition: all .4s ease-out
     }
     .eye-info-player {
         position: absolute

--- a/src/app/styl/views/player.styl
+++ b/src/app/styl/views/player.styl
@@ -48,12 +48,13 @@
     }
     .state-info-player {
         position: absolute
-        right: 60px
-        top: 80px
+        right: 90px
+        top: 110px
         font-size 50px
-        color: rgba(255,255,255,.9)
+        color: rgba(255,255,255,.3)
         z-index: 23
         display: none
+        transition: all .1s
     }
     .eye-info-player {
         position: absolute
@@ -74,12 +75,12 @@
     .details-info-player {
         display: none
         width: auto
-        background: rgba(31,31,31,0.74)
-        padding: 10px
+        background: rgba(31,31,31,0.7)
+        padding: 12px 20px
         top: 32px
         position: absolute
         right: 45px
-        border-radius: 2px
+        border-radius: 5px
 
         span {
             position relative
@@ -108,7 +109,7 @@
         height: 0
         border-left: 6px solid rgba(0,0,0,0)
         border-right: 6px solid rgba(0,0,0,0)
-        border-bottom: 6px solid rgba(31,31,31,0.74)
+        border-bottom: 6px solid rgba(31,31,31,0.7)
         top: -6px
         right: 15px
         position: absolute
@@ -407,7 +408,7 @@
 
 .player-header-background {
     position: absolute
-    background: linear-gradient(rgba(0,0,0,0.7), transparent) !important
+    background: linear-gradient(rgba(0,0,0,0.7), transparent 95%, transparent) !important
     width: 100% !important
     height: 75px !important
     z-index: 3
@@ -417,16 +418,18 @@
 .vjs-overlay,
 .vjs-overlay.vjs-overlay-top-left {
     position: absolute
-    width: 33%
-    font-size: 14px
-    background-color: transparent
+    width: auto
+    font-size: 16px
+    background-color: rgba(0,0,0,0.24)
     color: #fff
     font-family: "Open Sans Semibold"
     font-smoothing: antialiased
-    padding: 10px
+    padding: 14px
     border-radius: 3px
-    top: 65px
-    left: 5px
+    top: 80px
+    right: 30px
+    text-align: right
+    opacity: 0
 }
 
 .vjs-overlay {

--- a/src/app/styl/views/videojs.styl
+++ b/src/app/styl/views/videojs.styl
@@ -30,7 +30,7 @@
         position: absolute;
         bottom: 0;
         left: 0;
-        background-color: linear-gradient(transparent, rgba(0,0,0,0.7));
+        background: linear-gradient(transparent, rgba(0,0,0,0.7));
     }
 
     .vjs-control-bar {
@@ -826,7 +826,7 @@ body {
     display: block;
     opacity: .8;
     padding: 5px;
-    font-size: 10px;
+    font-size: 11px;
     position: absolute;
     z-index: 100000;
 }
@@ -846,7 +846,7 @@ body {
     border-radius: 3px;
     border-radius: 3px;
     padding: 5px 8px 4px;
-    background-color: #000;
+    background-color: rgba(0,0,0,0.9);
     color: #fff;
     max-width: 200px;
     text-align: center;

--- a/src/app/vendor/videojshooks.js
+++ b/src/app/vendor/videojshooks.js
@@ -86,11 +86,12 @@ vjs.TextTrack.prototype.load = function () {
         this.readyState_ = 1;
 
         var subsParams = function () {
-            var subtitles = $('.vjs-subtitles');
-            var vjsTextTrack = $('.vjs-text-track');
+            var subtitles = $('.vjs-subtitles'),
+                vjsTextTrack = $('.vjs-text-track'),
+                vjsTextTrackDsp = $('.vjs-text-track-display');
 
             vjsTextTrack.css('display', 'inline-block').drags();
-            vjsTextTrack.css('font-size', Settings.subtitle_size);
+            vjsTextTrackDsp.css('font-size', Settings.subtitle_size);
             if (win.isFullscreen) {
                 vjsTextTrack.css('font-size', '140%');
             }
@@ -438,6 +439,9 @@ vjs.Player.prototype.volume = function (percentAsDecimal) {
         this.cache_.volume = vol;
         this.techCall('setVolume', vol);
         vjs.setLocalStorage('volume', vol);
+        if ($('.vjs-overlay')) {
+            $('.vjs-overlay').css('opacity', '1');
+        }
 
         //let's save this bad boy
         AdvSettings.set('playerVolume', vol.toFixed(1));


### PR DESCRIPTION
* Player UI fix
(an extra `-color` in videojs.styl made the gradient background for the bottom video controls not show & general nitpicking)

* Subtitle scaling fix
(https://github.com/popcorn-official/popcorn-desktop/pull/1618/commits/05332818e6e768f7e8a1b543f592316caebac82f broke the subtitle scaling a bit which made the subtitles become tiny when fullscreen in/out, this fixes it)