### PR TITLE
Fix hiding the navigation filters, cast tooltips and fontawesome icons

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "backbone.marionette": "~3.x.x",
     "backbone.radio": "^2.0.0",
     "backbone.wreqr": "^1.4.0",
-    "bootstrap": "^3.4.1",
+    "bootstrap": "~3.3.7",
     "butter-provider": "0.11.0",
     "butter-sanitize": "^0.1.1",
     "butter-settings-popcorntime.io": "0.0.4",

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "backbone.marionette": "~3.x.x",
     "backbone.radio": "^2.0.0",
     "backbone.wreqr": "^1.4.0",
-    "bootstrap": "~3.3.7",
+    "bootstrap": "^3.4.1",
     "butter-provider": "0.11.0",
     "butter-sanitize": "^0.1.1",
     "butter-settings-popcorntime.io": "0.0.4",

--- a/src/app/lib/views/browser/filter_bar.js
+++ b/src/app/lib/views/browser/filter_bar.js
@@ -73,6 +73,7 @@
     },
     setActive: function(set) {
       var rightSearch = $('.right .search');
+      var navFilters = $('#nav-filters');
       var filterbarRandom = $('#filterbar-random');
 
       if (Settings.startScreen === 'Last Open') {
@@ -80,6 +81,7 @@
       }
 
       rightSearch.show();
+      navFilters.show();
       filterbarRandom.hide();
       $('.filter-bar')
         .find('.active')
@@ -109,10 +111,12 @@
           break;
         case 'Torrent-collection':
           rightSearch.hide();
+          navFilters.hide();
           $('#filterbar-torrent-collection').addClass('active');
           break;
         case 'Seedbox':
           rightSearch.hide();
+          navFilters.hide();
           $('#filterbar-seedbox').addClass('active');
           break;
       }

--- a/src/app/lib/views/movie_detail.js
+++ b/src/app/lib/views/movie_detail.js
@@ -276,7 +276,7 @@
         if (curSynopsis.cast !== '') {
           $('.overview').html(curSynopsis.crew + curSynopsis.cast + curSynopsis.old);
           $('.show-cast').attr('title', i18n.__('Hide cast')).tooltip('hide').tooltip('fixTitle');
-          $('.overview *').tooltip({html: true, container: 'body', placement: 'bottom', delay: {show: 200, hide: 0}, template: '<div class="tooltip" style="opacity:1"><div class="tooltip-inner" style="background-color:rgba(0,0,0,0);width:118px"></div></div>'});
+          $('.overview *').tooltip({html: true, sanitize: false, container: 'body', placement: 'bottom', delay: {show: 200, hide: 0}, template: '<div class="tooltip" style="opacity:1"><div class="tooltip-inner" style="background-color:rgba(0,0,0,0);width:118px"></div></div>'});
           curSynopsis.vstatus = true;
         } else {
           $('.show-cast').css({cursor: 'default', opacity: 0.4}).attr('title', i18n.__('Cast not available')).tooltip('hide').tooltip('fixTitle');
@@ -291,7 +291,7 @@
 
     showallCast: function () {
       $('.overview').html(curSynopsis.crew + curSynopsis.allcast + curSynopsis.old);
-      $('.overview *').tooltip({html: true, container: 'body', placement: 'bottom', delay: {show: 200, hide: 0}, template: '<div class="tooltip" style="opacity:1"><div class="tooltip-inner" style="background-color:rgba(0,0,0,0);width:118px"></div></div>'});
+      $('.overview *').tooltip({html: true, sanitize: false, container: 'body', placement: 'bottom', delay: {show: 200, hide: 0}, template: '<div class="tooltip" style="opacity:1"><div class="tooltip-inner" style="background-color:rgba(0,0,0,0);width:118px"></div></div>'});
     },
 
     onBeforeDestroy: function() {

--- a/src/app/lib/views/play_control.js
+++ b/src/app/lib/views/play_control.js
@@ -218,6 +218,7 @@
       App.vent.trigger('seedbox:show');
       $('.filter-bar').find('.active').removeClass('active');
       $('#filterbar-seedbox').addClass('active');
+      $('#nav-filters').hide();
     },
 
     startStreaming: function() {

--- a/src/app/lib/views/seedbox.js
+++ b/src/app/lib/views/seedbox.js
@@ -130,7 +130,7 @@
                     <div id="title-${torrent.infoHash}">${App.plugins.mediaName.getMediaName(torrent)}</div>
                 </a>
 
-                <i class="fa fa-trash-alt watched trash-torrent" id="trash-${torrent.infoHash}"></i>
+                <i class="fa fa-trash watched trash-torrent" id="trash-${torrent.infoHash}"></i>
                 <i class="fa fa-play watched resume-torrent" id="play-${torrent.infoHash}" style="display: ${torrent.paused ? '' : 'none'};"></i>
                 <i class="fa fa-pause-circle watched pause-torrent" id="resume-${torrent.infoHash}" style="display: ${torrent.paused ? 'none' : ''};"></i>
                 <i class="fa fa-upload watched" id="upload-${torrent.infoHash}"> 0 Kb/s</i>

--- a/src/app/lib/views/show_detail.js
+++ b/src/app/lib/views/show_detail.js
@@ -511,6 +511,7 @@
           App.vent.trigger('seedbox:show');
           $('.filter-bar').find('.active').removeClass('active');
           $('#filterbar-seedbox').addClass('active');
+          $('#nav-filters').hide();
         },
 
         closeDetails: function (e) {

--- a/src/app/templates/keyboard.tpl
+++ b/src/app/templates/keyboard.tpl
@@ -37,7 +37,7 @@
                         <td><%= i18n.__("Switch to previous tab") %></td>
                     </tr>
                     <tr>
-                        <td><span class="key control"><%= i18n.__("ctrl") %></span>+<span class="key">1</span><%= i18n.__("through") %></span><span class="key control"><%= i18n.__("ctrl") %></span>+<span class="key">3</span></td>
+                        <td><span class="key control"><%= i18n.__("ctrl") %></span>+<span class="key">1</span><%= i18n.__("through") %></span><span class="key control"><%= i18n.__("ctrl") %></span>+<span class="key">4</span></td>
                         <td><%= i18n.__("Switch to corresponding tab") %></td>
                     </tr>
                     <tr>

--- a/src/app/templates/movie-error.tpl
+++ b/src/app/templates/movie-error.tpl
@@ -1,7 +1,7 @@
 <div id="movie-error">
     <h2 class="error"><%= error %></h2>
     <div class="button retry-button" style="visibility:hidden">
-        <div class="button-text"><i class="fa fa-refresh">&nbsp;&nbsp;</i><%= i18n.__("Retry") %></div>
+        <div class="button-text"><i class="fa fa-sync">&nbsp;&nbsp;</i><%= i18n.__("Retry") %></div>
     </div>
     <div class="button online-search" style="visibility:hidden">
         <div class="button-text"><i class="fa fa-search">&nbsp;&nbsp;</i><%= i18n.__("Search on %s", Settings.onlineSearchEngine || "Strike") %></div>

--- a/src/app/templates/seedbox.tpl
+++ b/src/app/templates/seedbox.tpl
@@ -36,8 +36,8 @@
                        <% } else { %>
                             <div class="item-icon magnet-icon tooltipped" data-toogle="tooltip" data-placement="right" title="<%=i18n.__("Magnet link") %>"></div>
                         <% } %>
-                            <i class="fa fa-trash-o item-delete tooltipped" data-toggle="tooltip" data-placement="left" title="<%= i18n.__("Remove this torrent") %>"></i>
-                            <i class="fa fa-pencil item-rename tooltipped" data-toggle="tooltip" data-placement="left" title="<%= i18n.__("Rename this torrent") %>"></i>
+                            <i class="fa fa-trash item-delete tooltipped" data-toggle="tooltip" data-placement="left" title="<%= i18n.__("Remove this torrent") %>"></i>
+                            <i class="fa fa-pencil-alt item-rename tooltipped" data-toggle="tooltip" data-placement="left" title="<%= i18n.__("Rename this torrent") %>"></i>
                             </a>
                         </li>
                     <% }); %>

--- a/src/app/templates/settings-container.tpl
+++ b/src/app/templates/settings-container.tpl
@@ -349,7 +349,7 @@
                     </span>
                     <span class="advanced">
                         <div class="btn-settings syncTrakt" id="syncTrakt">
-                            <i class="fa fa-refresh">&nbsp;&nbsp;</i>
+                            <i class="fa fa-sync">&nbsp;&nbsp;</i>
                             <%= i18n.__("Sync With Trakt") %>
                         </div>
                     </span>
@@ -541,7 +541,7 @@
             <span>
                 <p><%= i18n.__("Cache Directory") %></p>
                 <input type="text" placeholder="<%= i18n.__("Cache Directory") %>" id="faketmpLocation" value="<%= Settings.tmpLocation %>" readonly="readonly" size="65" />
-                <i class="open-tmp-folder fa fa-folder-open-o tooltipped" data-toggle="tooltip" data-placement="auto" title="<%= i18n.__("Open Cache Directory") %>"></i>
+                <i class="open-tmp-folder fa fa-folder-open tooltipped" data-toggle="tooltip" data-placement="auto" title="<%= i18n.__("Open Cache Directory") %>"></i>
                 <input type="file" name="tmpLocation" id="tmpLocation" nwdirectory style="display: none;" nwworkingdir="<%= Settings.tmpLocation %>" />
             </span>
             <span>
@@ -565,18 +565,18 @@
             <span>
                 <p><%= i18n.__("Database Directory") %></p>
                 <input type="text" placeholder="<%= i18n.__("Database Directory") %>" id="fakedatabaseLocation" value="<%= Settings.databaseLocation %>" readonly="readonly" size="65" />
-                <i class="open-database-folder fa fa-folder-open-o tooltipped" data-toggle="tooltip" data-placement="auto" title="<%= i18n.__("Open Database Directory") %>"></i>
+                <i class="open-database-folder fa fa-folder-open tooltipped" data-toggle="tooltip" data-placement="auto" title="<%= i18n.__("Open Database Directory") %>"></i>
                 <input type="file" name="fakedatabaseLocation" id="fakedatabaseLocation" nwdirectory style="display: none;" nwworkingdir="<%= Settings.databaseLocation %>" />
             </span>
             <div class="btns advanced database import-database">
               <div class="btn-settings database">
                 <label class="import-database" for="importdatabase"  title="<%= i18n.__("Open File to Import") %>"><%= i18n.__("Import Database") %></label>
-                <i class="fa fa-level-down">&nbsp;&nbsp;</i>
+                <i class="fa fa-level-down-alt">&nbsp;&nbsp;</i>
                 <input type="file" id="importdatabase"  accept=".zip" style="display:none">
               </div>
               <div class="btn-settings database export-database">
                 <label class="export-database" for="exportdatabase" title="<%= i18n.__("Browse Directoy to save to") %>" ><%= i18n.__("Export Database") %></label>
-                <i class="fa fa-level-up">&nbsp;&nbsp;</i>
+                <i class="fa fa-level-up-alt">&nbsp;&nbsp;</i>
                 <input type="file" id="exportdatabase" style="display:none" nwdirectory>
                         </div>
 

--- a/src/app/templates/torrent_collection.tpl
+++ b/src/app/templates/torrent_collection.tpl
@@ -60,8 +60,8 @@
                    <% } else { %>
                         <div class="item-icon magnet-icon tooltipped" data-toogle="tooltip" data-placement="right" title="<%=i18n.__("Magnet link") %>"></div>
                     <% } %>
-                        <i class="fa fa-trash-o item-delete tooltipped" data-toggle="tooltip" data-placement="left" title="<%= i18n.__("Remove this torrent") %>"></i>
-                        <i class="fa fa-pencil item-rename tooltipped" data-toggle="tooltip" data-placement="left" title="<%= i18n.__("Rename this torrent") %>"></i>
+                        <i class="fa fa-trash item-delete tooltipped" data-toggle="tooltip" data-placement="left" title="<%= i18n.__("Remove this torrent") %>"></i>
+                        <i class="fa fa-pencil-alt item-rename tooltipped" data-toggle="tooltip" data-placement="left" title="<%= i18n.__("Rename this torrent") %>"></i>
                         </a>
                     </li>
                 <% }); %>
@@ -78,9 +78,9 @@
 
         <div class="collection-actions">
             <div class="collection-paste fa fa-paste tooltipped" data-toggle="tooltip" data-placement="left" title="<%= i18n.__("Paste a Magnet link") %>"></div>
-            <div class="collection-import fa fa-level-down tooltipped" data-toggle="tooltip" data-placement="left" title="<%= i18n.__("Import a Torrent file") %>"></div>
+            <div class="collection-import fa fa-level-down-alt tooltipped" data-toggle="tooltip" data-placement="left" title="<%= i18n.__("Import a Torrent file") %>"></div>
             <input class="collection-import-hidden" style="display:none" type="file" accept=".torrent"/>
-            <div class="collection-open fa fa-folder-open-o tooltipped" data-toggle="tooltip" data-placement="left" title="<%= i18n.__("Open Collection Directory") %>"></div>
+            <div class="collection-open fa fa-folder-open tooltipped" data-toggle="tooltip" data-placement="left" title="<%= i18n.__("Open Collection Directory") %>"></div>
         </div>
     </div>
 </div>


### PR DESCRIPTION
* Fix hiding the navigation filters
(the 'genre' and 'sort by' when in the Torrent Collection or Seedbox)

* Fix fontawesome
(https://github.com/popcorn-official/popcorn-desktop/pull/1623/commits/a553d20f5e2a5b4540de9c7b0f64e836d3f05c0a broke some icons)

* Update the keyboard shorcuts help
('ctrl+tab_number' goes up to 'ctrl+4' now with Favorites becoming a tab)

* Fix 'Cast' tooltip images
(https://github.com/popcorn-official/popcorn-desktop/pull/1623/commits/b0bcc9256bba971b54fbf10158ff8a2d37af3011 caused their template styling to be ignored)