### PR TITLE
Misc fixes

### DIFF
--- a/src/app/common.js
+++ b/src/app/common.js
@@ -129,7 +129,7 @@ Common.HealthButton = function (selector, retrieveHealthCallback) {
 				];
 
 				if (!isNaN(ratio)) {
-					tooltipPieces.push(`${i18n.__('Ratio:')} ${ratio.toFixed(2)}`);
+					tooltipPieces.push(` - ${i18n.__('Ratio:')} ${ratio.toFixed(2)}<br/>`);
 				}
 
 				if (!isNaN(seeds)) {
@@ -137,7 +137,7 @@ Common.HealthButton = function (selector, retrieveHealthCallback) {
 				}
 
 				if (!isNaN(peers)) {
-					tooltipPieces.push(`${i18n.__('Peers:')} ${peers}`);
+					tooltipPieces.push(` - ${i18n.__('Peers:')} ${peers}`);
 				}
 
 				getIcon()
@@ -146,7 +146,7 @@ Common.HealthButton = function (selector, retrieveHealthCallback) {
 					})
 					.removeClass('None Bad Medium Good Excellent')
 					.addClass(healthString)
-					.attr('data-original-title', tooltipPieces.join('<br/>'))
+					.attr('data-original-title', tooltipPieces.join(''))
 					.tooltip('fixTitle');
 			}
 		});

--- a/src/app/lib/streamer.js
+++ b/src/app/lib/streamer.js
@@ -105,7 +105,7 @@
             }
 
             App.WebTorrent.add(uri, {
-              path      : App.settings.tmpLocation + '/' + infoHash,
+              path      : App.settings.tmpLocation,
               maxConns  : 5,
               dht       : true,
               announce  : Settings.trackers.forced,
@@ -181,7 +181,7 @@
 
                 if (!this.torrent) {
                   this.torrent = App.WebTorrent.add(uri, {
-                      path: App.settings.tmpLocation + '/' + infoHash,
+                      path: App.settings.tmpLocation,
                       announce: Settings.trackers.forced
                   });
                 }

--- a/src/app/lib/streamer.js
+++ b/src/app/lib/streamer.js
@@ -53,7 +53,7 @@
                   }
 
                   App.WebTorrent.add(data, {
-                      path      : App.settings.tmpLocation + '/' + file,
+                      path      : App.settings.tmpLocation,
                       maxConns  : 5,
                       dht       : true,
                       announce  : Settings.trackers.forced,

--- a/src/app/lib/views/browser/filter_bar.js
+++ b/src/app/lib/views/browser/filter_bar.js
@@ -73,6 +73,7 @@
     },
     setActive: function(set) {
       var rightSearch = $('.right .search');
+      var navFilters = $('#nav-filters');
       var filterbarRandom = $('#filterbar-random');
 
       if (Settings.startScreen === 'Last Open') {
@@ -80,6 +81,7 @@
       }
 
       rightSearch.show();
+      navFilters.show();
       filterbarRandom.hide();
       $('.filter-bar')
         .find('.active')
@@ -109,10 +111,12 @@
           break;
         case 'Torrent-collection':
           rightSearch.hide();
+          navFilters.hide();
           $('#filterbar-torrent-collection').addClass('active');
           break;
         case 'Seedbox':
           rightSearch.hide();
+          navFilters.hide();
           $('#filterbar-seedbox').addClass('active');
           break;
       }

--- a/src/app/lib/views/movie_detail.js
+++ b/src/app/lib/views/movie_detail.js
@@ -276,7 +276,7 @@
         if (curSynopsis.cast !== '') {
           $('.overview').html(curSynopsis.crew + curSynopsis.cast + curSynopsis.old);
           $('.show-cast').attr('title', i18n.__('Hide cast')).tooltip('hide').tooltip('fixTitle');
-          $('.overview *').tooltip({html: true, container: 'body', placement: 'bottom', delay: {show: 200, hide: 0}, template: '<div class="tooltip" style="opacity:1"><div class="tooltip-inner" style="background-color:rgba(0,0,0,0);width:118px"></div></div>'});
+          $('.overview *').tooltip({html: true, sanitize: false, container: 'body', placement: 'bottom', delay: {show: 200, hide: 0}, template: '<div class="tooltip" style="opacity:1"><div class="tooltip-inner" style="background-color:rgba(0,0,0,0);width:118px"></div></div>'});
           curSynopsis.vstatus = true;
         } else {
           $('.show-cast').css({cursor: 'default', opacity: 0.4}).attr('title', i18n.__('Cast not available')).tooltip('hide').tooltip('fixTitle');
@@ -291,7 +291,7 @@
 
     showallCast: function () {
       $('.overview').html(curSynopsis.crew + curSynopsis.allcast + curSynopsis.old);
-      $('.overview *').tooltip({html: true, container: 'body', placement: 'bottom', delay: {show: 200, hide: 0}, template: '<div class="tooltip" style="opacity:1"><div class="tooltip-inner" style="background-color:rgba(0,0,0,0);width:118px"></div></div>'});
+      $('.overview *').tooltip({html: true, sanitize: false, container: 'body', placement: 'bottom', delay: {show: 200, hide: 0}, template: '<div class="tooltip" style="opacity:1"><div class="tooltip-inner" style="background-color:rgba(0,0,0,0);width:118px"></div></div>'});
     },
 
     onBeforeDestroy: function() {

--- a/src/app/lib/views/play_control.js
+++ b/src/app/lib/views/play_control.js
@@ -218,6 +218,7 @@
       App.vent.trigger('seedbox:show');
       $('.filter-bar').find('.active').removeClass('active');
       $('#filterbar-seedbox').addClass('active');
+      $('#nav-filters').hide();
     },
 
     startStreaming: function() {

--- a/src/app/lib/views/player/loading.js
+++ b/src/app/lib/views/player/loading.js
@@ -387,12 +387,7 @@
     },
 
     tempf: function (e) {
-      try { var infoHash = this.model.attributes.streamInfo.attributes.torrentModel.attributes.torrent.infoHash; } catch (err) {}
-      if (infoHash) {
-        nw.Shell.openExternal(Settings.tmpLocation + '/' + infoHash);
-      } else {
-        nw.Shell.openExternal(Settings.tmpLocation);
-      }
+      nw.Shell.openExternal(Settings.tmpLocation);
     },
 
     filenameovrflsh: function () {

--- a/src/app/lib/views/player/loading.js
+++ b/src/app/lib/views/player/loading.js
@@ -387,7 +387,12 @@
     },
 
     tempf: function (e) {
-      nw.Shell.openExternal(Settings.tmpLocation);
+      try { var infoHash = this.model.attributes.streamInfo.attributes.torrentModel.attributes.torrent.infoHash; } catch (err) {}
+      if (infoHash) {
+        nw.Shell.openExternal(Settings.tmpLocation + '/' + infoHash);
+      } else {
+        nw.Shell.openExternal(Settings.tmpLocation);
+      }
     },
 
     filenameovrflsh: function () {

--- a/src/app/lib/views/seedbox.js
+++ b/src/app/lib/views/seedbox.js
@@ -242,7 +242,7 @@
 		    if (torrent) {
 				torrent.destroy(() => {
 					fs.unlinkSync(path.join(torrentsDir, torrent.infoHash));
-					rimraf(path.join(App.settings.tmpLocation, torrent.infoHash), () => {
+					rimraf(path.join(App.settings.tmpLocation, torrent.name), () => {
 					});
 				});
 

--- a/src/app/lib/views/seedbox.js
+++ b/src/app/lib/views/seedbox.js
@@ -130,7 +130,7 @@
                     <div id="title-${torrent.infoHash}">${App.plugins.mediaName.getMediaName(torrent)}</div>
                 </a>
 
-                <i class="fa fa-trash-alt watched trash-torrent" id="trash-${torrent.infoHash}"></i>
+                <i class="fa fa-trash watched trash-torrent" id="trash-${torrent.infoHash}"></i>
                 <i class="fa fa-play watched resume-torrent" id="play-${torrent.infoHash}" style="display: ${torrent.paused ? '' : 'none'};"></i>
                 <i class="fa fa-pause-circle watched pause-torrent" id="resume-${torrent.infoHash}" style="display: ${torrent.paused ? 'none' : ''};"></i>
                 <i class="fa fa-upload watched" id="upload-${torrent.infoHash}"> 0 Kb/s</i>

--- a/src/app/lib/views/show_detail.js
+++ b/src/app/lib/views/show_detail.js
@@ -511,6 +511,7 @@
           App.vent.trigger('seedbox:show');
           $('.filter-bar').find('.active').removeClass('active');
           $('#filterbar-seedbox').addClass('active');
+          $('#nav-filters').hide();
         },
 
         closeDetails: function (e) {

--- a/src/app/styl/views/movie_detail.styl
+++ b/src/app/styl/views/movie_detail.styl
@@ -251,7 +251,7 @@
 
             height: 70px
             line-height: 35px
-            margin: 10px 25px 1px 16px
+            margin: -1px 25px 1px 16px
 
             .setup-container
               display: flex

--- a/src/app/styl/views/torrent_collection.styl
+++ b/src/app/styl/views/torrent_collection.styl
@@ -169,6 +169,7 @@
                 cursor text
                 outline 0 !important
                 height 30px
+                min-width 264px
 
             .online-search
                 margin-left 5px

--- a/src/app/templates/keyboard.tpl
+++ b/src/app/templates/keyboard.tpl
@@ -37,7 +37,7 @@
                         <td><%= i18n.__("Switch to previous tab") %></td>
                     </tr>
                     <tr>
-                        <td><span class="key control"><%= i18n.__("ctrl") %></span>+<span class="key">1</span><%= i18n.__("through") %></span><span class="key control"><%= i18n.__("ctrl") %></span>+<span class="key">3</span></td>
+                        <td><span class="key control"><%= i18n.__("ctrl") %></span>+<span class="key">1</span><%= i18n.__("through") %></span><span class="key control"><%= i18n.__("ctrl") %></span>+<span class="key">4</span></td>
                         <td><%= i18n.__("Switch to corresponding tab") %></td>
                     </tr>
                     <tr>

--- a/src/app/templates/movie-error.tpl
+++ b/src/app/templates/movie-error.tpl
@@ -1,7 +1,7 @@
 <div id="movie-error">
     <h2 class="error"><%= error %></h2>
     <div class="button retry-button" style="visibility:hidden">
-        <div class="button-text"><i class="fa fa-refresh">&nbsp;&nbsp;</i><%= i18n.__("Retry") %></div>
+        <div class="button-text"><i class="fa fa-sync">&nbsp;&nbsp;</i><%= i18n.__("Retry") %></div>
     </div>
     <div class="button online-search" style="visibility:hidden">
         <div class="button-text"><i class="fa fa-search">&nbsp;&nbsp;</i><%= i18n.__("Search on %s", Settings.onlineSearchEngine || "Strike") %></div>

--- a/src/app/templates/seedbox.tpl
+++ b/src/app/templates/seedbox.tpl
@@ -36,8 +36,8 @@
                        <% } else { %>
                             <div class="item-icon magnet-icon tooltipped" data-toogle="tooltip" data-placement="right" title="<%=i18n.__("Magnet link") %>"></div>
                         <% } %>
-                            <i class="fa fa-trash-o item-delete tooltipped" data-toggle="tooltip" data-placement="left" title="<%= i18n.__("Remove this torrent") %>"></i>
-                            <i class="fa fa-pencil item-rename tooltipped" data-toggle="tooltip" data-placement="left" title="<%= i18n.__("Rename this torrent") %>"></i>
+                            <i class="fa fa-trash item-delete tooltipped" data-toggle="tooltip" data-placement="left" title="<%= i18n.__("Remove this torrent") %>"></i>
+                            <i class="fa fa-pencil-alt item-rename tooltipped" data-toggle="tooltip" data-placement="left" title="<%= i18n.__("Rename this torrent") %>"></i>
                             </a>
                         </li>
                     <% }); %>

--- a/src/app/templates/settings-container.tpl
+++ b/src/app/templates/settings-container.tpl
@@ -6,36 +6,10 @@
         <div class="title"><%= i18n.__("Settings") %></div>
         <div class="content">
             <span>
-                <i class="fa fa-keyboard-o keyboard tooltipped" data-toggle="tooltip" data-placement="bottom" title="<%= i18n.__("Keyboard Shortcuts") %>"></i>
+                <i class="far fa-keyboard keyboard tooltipped" data-toggle="tooltip" data-placement="bottom" title="<%= i18n.__("Keyboard Shortcuts") %>"></i>
                 <i class="fa fa-question-circle help tooltipped" data-toggle="tooltip" data-placement="bottom" title="<%= i18n.__("Help Section") %>"></i>
                 <input id="show-advanced-settings" class="settings-checkbox" name="showAdvancedSettings" type="checkbox" <%=(Settings.showAdvancedSettings? "checked":"")%>>
                 <label class="settings-label" for="show-advanced-settings"><%= i18n.__("Show advanced settings") %></label>
-            </span>
-        </div>
-    </section>
-
-    <section id="apiserver" class="advanced">
-        <div class="title"><%= i18n.__("Server") %></div>
-        <div class="content">
-            <span>
-                <div class="opensubtitles-options">
-                    <p><%= i18n.__("Custom API Server") %></p>
-                    <input type="text" size="100" id="apiServer" name="apiServer" value="<%= Settings.apiServer %>"
-                           placeholder="http(s)://server.com/ (support .onion and .i2p urls)">
-                    <div class="loading-spinner" style="display: none"></div>
-                    <div class="valid-tick" style="display: none"></div>
-                    <div class="invalid-cross" style="display: none"></div>
-                </div>
-            </span>
-            <span>
-                <div class="opensubtitles-options">
-                    <p><%= i18n.__("Proxy Server") %></p>
-                    <input type="text" size="50" id="proxyServer" name="proxyServer" value="<%= Settings.proxyServer %>"
-                           placeholder="host:port (127.0.0.1:9050 or 127.0.0.1:4447)">
-                    <div class="loading-spinner" style="display: none"></div>
-                    <div class="valid-tick" style="display: none"></div>
-                    <div class="invalid-cross" style="display: none"></div>
-                </div>
             </span>
         </div>
     </section>
@@ -49,10 +23,9 @@
                     <%
                         var langs = "";
                         for(var key in App.Localization.allTranslations) {
-                                key = App.Localization.allTranslations[key];
-                                if (App.Localization.langcodes[key] !== undefined) {
-                                langs += "<option "+(Settings.language == key? "selected='selected'":"")+" value='"+key+"'>"+
-                                            App.Localization.langcodes[key].nativeName+"</option>";
+                            key = App.Localization.allTranslations[key];
+                            if (App.Localization.langcodes[key] !== undefined) {
+                                langs += "<option "+(Settings.language == key? "selected='selected'":"")+" value='"+key+"'>"+ App.Localization.langcodes[key].nativeName+"</option>";
                             }
                         }
                     %>
@@ -60,7 +33,6 @@
                     <div class="dropdown-arrow"></div>
                 </div>
             </span>
-
             <span>
                 <div class="dropdown pct-theme">
                     <p><%= i18n.__("Theme") %></p>
@@ -87,13 +59,11 @@
                     <div class="dropdown-arrow"></div>
                 </div>
             </span>
-
             <span class="advanced">
                 <div class="dropdown start-screen">
                     <p><%= i18n.__("Start Screen") %></p>
                         <%
                             var arr_screens = ["Movies","TV Series","Anime","Favorites","Watchlist","Last Open"];
-
                             var selct_start_screen = "";
                             for(var key in arr_screens) {
                                 selct_start_screen += "<option "+(Settings.start_screen == arr_screens[key]? "selected='selected'":"")+" value='"+arr_screens[key]+"'>"+i18n.__(arr_screens[key])+"</option>";
@@ -103,8 +73,7 @@
                     <div class="dropdown-arrow"></div>
                 </div>
             </span>
-
-            <span class="advanced">
+            <span>
                 <input class="settings-checkbox" name="translateSynopsis" id="translateSynopsis" type="checkbox" <%=(Settings.translateSynopsis? "checked='checked'":"")%>>
                 <label class="settings-label" for="translateSynopsis"><%= i18n.__("Translate Synopsis") %></label>
             </span>
@@ -116,17 +85,14 @@
                 <input class="settings-checkbox" name="alwaysOnTop" id="alwaysOnTop" type="checkbox" <%=(Settings.alwaysOnTop? "checked='checked'":"")%>>
                 <label class="settings-label" for="alwaysOnTop"><%= i18n.__("Always On Top") %></label>
             </span>
-
             <span class="advanced">
                 <input class="settings-checkbox" name="animeTabDisable" id="animeTabDisable" type="checkbox" <%=(Settings.animeTabDisable ? "checked='checked'":"")%>>
                 <label class="settings-label" for="animeTabDisable"><%= i18n.__("Disable Anime Tab") %></label>
             </span>
-
             <span class="advanced">
                 <input class="settings-checkbox" name="rememberFilters" id="rememberFilters" type="checkbox" <%=(Settings.rememberFilters? "checked='checked'":"")%>>
                 <label class="settings-label" for="rememberFilters"><%= i18n.__("Remember Filters") %></label>
             </span>
-
             <span class="advanced">
                 <div class="dropdown watchedCovers">
                     <p><%= i18n.__("Watched Items") %></p>
@@ -136,7 +102,6 @@
                                 "fade": "Fade",
                                 "hide": "Hide"
                             };
-
                             var select_watched_cover = "";
                             for(var key in watch_type) {
                                 select_watched_cover += "<option "+(Settings.watchedCovers == key? "selected='selected'":"")+" value='"+key+"'>"+i18n.__(watch_type[key])+"</option>";
@@ -146,7 +111,24 @@
                     <div class="dropdown-arrow"></div>
                 </div>
             </span>
-
+            <span class="advanced">
+                <div class="dropdown poster_size">
+                   <p><%= i18n.__("Poster Size") %></p>
+                        <%
+                            var pos_type = {"134": "100%", "154": "113%", "174": "125%", "194": "138%", "214": "150%", "234": "163%", "254": "175%", "274": "188%", "294": "200%"};
+                            var pos_sizes = "";
+                            for(var key in pos_type) {
+                                pos_sizes += "<option "+(Settings.postersWidth == key? "selected='selected'":"")+" value='"+key+"'>"+i18n.__(pos_type[key])+"</option>";
+                            }
+                        %>
+                    <select name="poster_size"><%=pos_sizes%></select>
+                    <div class="dropdown-arrow"></div>
+                </div>
+            </span>
+            <span class="advanced">
+                <p><%= i18n.__("UI Scaling") %></p>
+                <input id="bigPicture" type="text" size="4" name="bigPicture" value="<%=Settings.bigPicture%>%"/>&nbsp;&nbsp;<em><%= i18n.__("(25% - 400%)") %></em>
+            </span>
         </div>
     </section>
 
@@ -159,11 +141,9 @@
                     <%
                         var sub_langs = "<option "+(Settings.subtitle_language == "none"? "selected='selected'":"")+" value='none'>" +
                                             i18n.__("Disabled") + "</option>";
-
                         for(var key in App.Localization.langcodes) {
                             if (App.Localization.langcodes[key].subtitle !== undefined && App.Localization.langcodes[key].subtitle == true) {
-                                sub_langs += "<option "+(Settings.subtitle_language == key? "selected='selected'":"")+" value='"+key+"'>"+
-                                                App.Localization.langcodes[key].nativeName+"</option>";
+                                sub_langs += "<option "+(Settings.subtitle_language == key? "selected='selected'":"")+" value='"+key+"'>"+ App.Localization.langcodes[key].nativeName+"</option>";
                             }
                         }
                     %>
@@ -171,7 +151,6 @@
                     <div class="dropdown-arrow"></div>
                 </div>
             </span>
-
             <span class="advanced">
                 <div class="dropdown subtitles-font">
                     <p><%= i18n.__("Font") %></p>
@@ -196,13 +175,11 @@
                             {name:"Ubuntu", id:"ubuntu"},
                             {name:"Verdana", id:"verdana"},
                         ];
-
                         var font_folder = path.resolve({
                             win32:  "/Windows/fonts",
                             darwin: "/Library/Fonts",
                             linux:  "/usr/share/fonts"
                         }[process.platform]);
-
                         var files = [];
                         var recursive = function (dir) {
                             if (fs.statSync(dir).isDirectory()) {
@@ -218,7 +195,6 @@
                             recursive(font_folder);
                         } catch (e) {}
                         var avail_fonts = ["Arial"];
-
                         for (var i in arr_fonts) {
                             for (var key in files) {
                                 var found = files[key].toLowerCase();
@@ -229,7 +205,6 @@
                                 }
                             }
                         }
-
                         var sub_fonts = "";
                         for (var key in avail_fonts) {
                             sub_fonts += "<option "+(Settings.subtitle_font == avail_fonts[key]+",Arial"? "selected='selected'":"")+" value='"+avail_fonts[key]+",Arial'>"+avail_fonts[key]+"</option>";
@@ -239,13 +214,11 @@
                     <div class="dropdown-arrow"></div>
                 </div>
             </span>
-
             <span class="advanced">
                 <div class="dropdown subtitles-decoration">
                     <p><%= i18n.__("Decoration") %></p>
                     <%
                         var arr_deco = ["None", "Outline", "Opaque Background", "See-through Background"];
-
                         var sub_deco = "";
                         for(var key in arr_deco) {
                             sub_deco += "<option "+(Settings.subtitle_decoration == arr_deco[key]? "selected='selected'":"")+" value='"+arr_deco[key]+"'>"+i18n.__(arr_deco[key])+"</option>";
@@ -255,13 +228,11 @@
                     <div class="dropdown-arrow"></div>
                 </div>
             </span>
-
             <span>
                 <div class="dropdown subtitles-size">
                     <p><%= i18n.__("Size") %></p>
                     <%
                         var arr_sizes = ["20px","22px","24px","26px","28px","30px","32px","34px","36px","38px","40px","42px","44px","46px","48px","50px","52px","54px","56px","58px","60px"];
-
                         var sub_sizes = "";
                         for(var key in arr_sizes) {
                             sub_sizes += "<option "+(Settings.subtitle_size == arr_sizes[key]? "selected='selected'":"")+" value='"+arr_sizes[key]+"'>"+arr_sizes[key]+"</option>";
@@ -271,7 +242,6 @@
                     <div class="dropdown-arrow"></div>
                 </div>
             </span>
-
             <span class="advanced">
                 <div class="subtitles-custom">
                     <p><%= i18n.__("Color") %></p>
@@ -290,7 +260,6 @@
                 <input class="settings-checkbox" name="subtitles_bold" id="subsbold" type="checkbox" <%=(Settings.subtitles_bold? "checked='checked'":"")%>>
                 <label class="settings-label" for="subsbold"><%= i18n.__("Bold") %></label>
             </span>
-
         </div>
     </section>
 
@@ -314,10 +283,11 @@
             </span>
         </div>
     </section>
+
     <section id="playback">
         <div class="title"><%= i18n.__("Playback") %></div>
         <div class="content">
-            <span class="advanced">
+            <span>
                 <input class="settings-checkbox" name="alwaysFullscreen" id="alwaysFullscreen" type="checkbox" <%=(Settings.alwaysFullscreen? "checked='checked'":"")%>>
                 <label class="settings-label" for="alwaysFullscreen"><%= i18n.__("Always start playing in fullscreen") %></label>
             </span>
@@ -374,16 +344,16 @@
     <% } %>
 
     <% if(App.TVShowTime) { %>
-	<section id="tvshowtime">
-		<div class="title">TVShow Time</div>
-		<div class="content">
-			<div class="tvshowtime-options <%= App.TVShowTime.authenticated ? " authenticated" : "" %>">
-				<% if(App.TVShowTime.authenticated) { %>
+    <section id="tvshowtime">
+        <div class="title">TVShow Time</div>
+        <div class="content">
+            <div class="tvshowtime-options <%= App.TVShowTime.authenticated ? " authenticated" : "" %>">
+                <% if(App.TVShowTime.authenticated) { %>
                     <span>
                         <%= i18n.__("You are currently connected to %s", "TVShow Time") %>.
                         <a id="disconnect-tvst" class="unauthtext" href="#"><%= i18n.__("Disconnect account") %></a>
                     </span>
-				<% } else { %>
+                <% } else { %>
                     <span>
                         <div class="btn-settings" id="connect-with-tvst">
                             <i class="fa fa-user">&nbsp;&nbsp;</i>
@@ -391,10 +361,10 @@
                         </div>
                         <div class="tvst-loading-spinner" style="display: none"></div>
                     </span>
-				<% } %>
-			</div>
-		</div>
-	</section>
+                <% } %>
+            </div>
+        </div>
+    </section>
     <% } %>
 
     <section id="opensubtitles">
@@ -407,17 +377,17 @@
                         <a id="unauthOpensubtitles" class="unauthtext" href="#"><%= i18n.__("Disconnect account") %></a>
                     </span>
                 <% } else { %>
-					<span>
-						<p><%= i18n.__("Username") %></p>
-						<input type="text" size="50" id="opensubtitlesUsername" name="opensubtitlesUsername">
+                    <span>
+                        <p><%= i18n.__("Username") %></p>
+                        <input type="text" size="50" id="opensubtitlesUsername" name="opensubtitlesUsername">
                         <div class="loading-spinner" style="display: none"></div>
                         <div class="valid-tick" style="display: none"></div>
                         <div class="invalid-cross" style="display: none"></div>
-					</span>
-					<span>
-						<p><%= i18n.__("Password") %></p>
-						<input type="password" size="50" id="opensubtitlesPassword" name="opensubtitlesPassword">
-					</span>
+                    </span>
+                    <span>
+                        <p><%= i18n.__("Password") %></p>
+                        <input type="password" size="50" id="opensubtitlesPassword" name="opensubtitlesPassword">
+                    </span>
                     <div class="btns database">
                         <div class="btn-settings database" id="authOpensubtitles">
                             <i class="fa fa-user">&nbsp;&nbsp;</i>
@@ -427,9 +397,9 @@
                             <i class="fa fa-user-plus">&nbsp;&nbsp;</i><%= i18n.__("Create account") %>
                         </a>
                     </div>                    
-					<span>
-						<em><%= i18n.__("* %s stores an encrypted hash of your password in your local database", Settings.projectName) %></em>
-					</span>
+                    <span>
+                        <em><%= i18n.__("* %s stores an encrypted hash of your password in your local database", Settings.projectName) %></em>
+                    </span>
                 <% } %>
                 <span class="advanced">
                     <input class="settings-checkbox" name="opensubtitlesAutoUpload" id="opensubtitlesAutoUpload" type="checkbox" <%=(Settings.opensubtitlesAutoUpload? "checked='checked'":"")%>>
@@ -497,6 +467,30 @@
         </div>
     </section>
 
+    <section id="apiserver" class="advanced">
+        <div class="title"><%= i18n.__("Server") %></div>
+        <div class="content">
+            <span>
+                <div class="opensubtitles-options">
+                    <p><%= i18n.__("Custom API Server") %></p>
+                    <input type="text" size="100" id="apiServer" name="apiServer" value="<%= Settings.apiServer %>" placeholder="http(s)://server.com/ (support .onion and .i2p urls)">
+                    <div class="loading-spinner" style="display: none"></div>
+                    <div class="valid-tick" style="display: none"></div>
+                    <div class="invalid-cross" style="display: none"></div>
+                </div>
+            </span>
+            <span>
+                <div class="opensubtitles-options">
+                    <p><%= i18n.__("Proxy Server") %></p>
+                    <input type="text" size="50" id="proxyServer" name="proxyServer" value="<%= Settings.proxyServer %>" placeholder="host:port (127.0.0.1:9050 or 127.0.0.1:4447)">
+                    <div class="loading-spinner" style="display: none"></div>
+                    <div class="valid-tick" style="display: none"></div>
+                    <div class="invalid-cross" style="display: none"></div>
+                </div>
+            </span>
+        </div>
+    </section>
+
     <section id="connection" class="advanced">
         <div class="title"><%= i18n.__("Connection") %></div>
         <div class="content">
@@ -531,7 +525,6 @@
                 <input class="settings-checkbox" name="vpnEnabled" id="vpnEnabled" type="checkbox" <%=(Settings.vpnEnabled? "checked='checked'":"")%>>
                 <label class="settings-label" for="vpnEnabled"><%= i18n.__("Enable VPN") %></label>
             </span>
-
         </div>
     </section>
 
@@ -569,20 +562,20 @@
                 <input type="file" name="fakedatabaseLocation" id="fakedatabaseLocation" nwdirectory style="display: none;" nwworkingdir="<%= Settings.databaseLocation %>" />
             </span>
             <div class="btns advanced database import-database">
-              <div class="btn-settings database">
-                <label class="import-database" for="importdatabase"  title="<%= i18n.__("Open File to Import") %>"><%= i18n.__("Import Database") %></label>
-                <i class="fa fa-level-down-alt">&nbsp;&nbsp;</i>
-                <input type="file" id="importdatabase"  accept=".zip" style="display:none">
-              </div>
-              <div class="btn-settings database export-database">
-                <label class="export-database" for="exportdatabase" title="<%= i18n.__("Browse Directoy to save to") %>" ><%= i18n.__("Export Database") %></label>
-                <i class="fa fa-level-up-alt">&nbsp;&nbsp;</i>
-                <input type="file" id="exportdatabase" style="display:none" nwdirectory>
-                        </div>
-
+                <div class="btn-settings database">
+                    <label class="import-database" for="importdatabase"  title="<%= i18n.__("Open File to Import") %>"><%= i18n.__("Import Database") %></label>
+                    <i class="fa fa-level-down-alt">&nbsp;&nbsp;</i>
+                    <input type="file" id="importdatabase"  accept=".zip" style="display:none">
+                </div>
+                <div class="btn-settings database export-database">
+                    <label class="export-database" for="exportdatabase" title="<%= i18n.__("Browse Directoy to save to") %>" ><%= i18n.__("Export Database") %></label>
+                    <i class="fa fa-level-up-alt">&nbsp;&nbsp;</i>
+                    <input type="file" id="exportdatabase" style="display:none" nwdirectory>
+                </div>
             </div>
         </div>
     </section>
+
     <section id="miscellaneous" class="advanced">
         <div class="title"><%= i18n.__("Miscellaneous") %></div>
         <div class="content">
@@ -594,7 +587,6 @@
                                 "firstUnwatched": "First Unwatched Episode",
                                 "next": "Next Episode In Series"
                             };
-
                             var selected_tv_detail_jump = "";
                             for(var key in tv_detail_jump_to) {
                                 selected_tv_detail_jump += "<option "+(Settings.tv_detail_jump_to == key? "selected='selected'":"")+" value='"+key+"'>"+i18n.__(tv_detail_jump_to[key])+"</option>";
@@ -620,29 +612,12 @@
                 <input class="settings-checkbox" name="minimizeToTray" id="minimizeToTray" type="checkbox" <%=(Settings.minimizeToTray? "checked='checked'":"")%>>
                 <label class="settings-label" for="minimizeToTray"><%= i18n.__("Minimize to Tray") %></label>
             </span>
-            <span>
-                <div class="dropdown poster_size">
-                   <p><%= i18n.__("Poster Size") %></p>
-                        <%
-                            var pos_type = {"134": "100%", "154": "113%", "174": "125%", "194": "138%", "214": "150%", "234": "163%", "254": "175%", "274": "188%", "294": "200%"};
-                            var pos_sizes = "";
-                            for(var key in pos_type) {
-                                pos_sizes += "<option "+(Settings.postersWidth == key? "selected='selected'":"")+" value='"+key+"'>"+i18n.__(pos_type[key])+"</option>";
-                            }
-                        %>
-                    <select name="poster_size"><%=pos_sizes%></select>
-                    <div class="dropdown-arrow"></div>
-                </div>
-            </span>
-            <span>
-                <p><%= i18n.__("UI Scaling") %></p>
-                <input id="bigPicture" type="text" size="4" name="bigPicture" value="<%=Settings.bigPicture%>%"/>&nbsp;&nbsp;<em><%= i18n.__("(25% - 400%)") %></em>
-            </span>
         </div>
     </section>
+
     <div class="btns">
-        <div class="btn-settings flush-bookmarks advanced"><%= i18n.__("Flush bookmarks database") %></div>
-        <div class="btn-settings flush-subtitles advanced"><%= i18n.__("Flush subtitles cache") %></div>
+        <div class="btn-settings flush-bookmarks"><%= i18n.__("Flush bookmarks database") %></div>
+        <div class="btn-settings flush-subtitles"><%= i18n.__("Flush subtitles cache") %></div>
         <div class="btn-settings flush-databases"><%= i18n.__("Flush all databases") %></div>
         <div class="btn-settings default-settings"><%= i18n.__("Reset to Default Settings") %></div>
     </div>

--- a/src/app/templates/settings-container.tpl
+++ b/src/app/templates/settings-container.tpl
@@ -295,7 +295,6 @@
                 <input class="settings-checkbox" name="playNextEpisodeAuto" id="playNextEpisodeAuto" type="checkbox" <%=(Settings.playNextEpisodeAuto? "checked='checked'":"")%>>
                 <label class="settings-label" for="playNextEpisodeAuto"><%= i18n.__("Play next episode automatically") %></label>
             </span>
-
         </div>
     </section>
 

--- a/src/app/templates/settings-container.tpl
+++ b/src/app/templates/settings-container.tpl
@@ -412,12 +412,12 @@
         <div class="title"><%= i18n.__("Features") %></div>
         <div class="content">
             <span>
-                <input class="settings-checkbox" name="activateTorrentCollection" id="activateTorrentCollection" type="checkbox" <%=(Settings.activateTorrentCollection? "checked='checked'":"")%>>
-                <label class="settings-label" for="activateTorrentCollection"><%= i18n.__("Torrent Collection") %></label>
-            </span>
-            <span>
                 <input class="settings-checkbox" name="activateWatchlist" id="activateWatchlist" type="checkbox" <%=(Settings.activateWatchlist? "checked='checked'":"")%>>
                 <label class="settings-label" for="activateWatchlist"><%= i18n.__("Watchlist") %></label>
+            </span>
+            <span>
+                <input class="settings-checkbox" name="activateTorrentCollection" id="activateTorrentCollection" type="checkbox" <%=(Settings.activateTorrentCollection? "checked='checked'":"")%>>
+                <label class="settings-label" for="activateTorrentCollection"><%= i18n.__("Torrent Collection") %></label>
             </span>
             <span>
                 <input class="settings-checkbox" name="activateTempf" id="activateTempf" type="checkbox" <%=(Settings.activateTempf? "checked='checked'":"")%>>

--- a/src/app/templates/settings-container.tpl
+++ b/src/app/templates/settings-container.tpl
@@ -349,7 +349,7 @@
                     </span>
                     <span class="advanced">
                         <div class="btn-settings syncTrakt" id="syncTrakt">
-                            <i class="fa fa-refresh">&nbsp;&nbsp;</i>
+                            <i class="fa fa-sync">&nbsp;&nbsp;</i>
                             <%= i18n.__("Sync With Trakt") %>
                         </div>
                     </span>
@@ -541,7 +541,7 @@
             <span>
                 <p><%= i18n.__("Cache Directory") %></p>
                 <input type="text" placeholder="<%= i18n.__("Cache Directory") %>" id="faketmpLocation" value="<%= Settings.tmpLocation %>" readonly="readonly" size="65" />
-                <i class="open-tmp-folder fa fa-folder-open-o tooltipped" data-toggle="tooltip" data-placement="auto" title="<%= i18n.__("Open Cache Directory") %>"></i>
+                <i class="open-tmp-folder fa fa-folder-open tooltipped" data-toggle="tooltip" data-placement="auto" title="<%= i18n.__("Open Cache Directory") %>"></i>
                 <input type="file" name="tmpLocation" id="tmpLocation" nwdirectory style="display: none;" nwworkingdir="<%= Settings.tmpLocation %>" />
             </span>
             <span>
@@ -565,18 +565,18 @@
             <span>
                 <p><%= i18n.__("Database Directory") %></p>
                 <input type="text" placeholder="<%= i18n.__("Database Directory") %>" id="fakedatabaseLocation" value="<%= Settings.databaseLocation %>" readonly="readonly" size="65" />
-                <i class="open-database-folder fa fa-folder-open-o tooltipped" data-toggle="tooltip" data-placement="auto" title="<%= i18n.__("Open Database Directory") %>"></i>
+                <i class="open-database-folder fa fa-folder-open tooltipped" data-toggle="tooltip" data-placement="auto" title="<%= i18n.__("Open Database Directory") %>"></i>
                 <input type="file" name="fakedatabaseLocation" id="fakedatabaseLocation" nwdirectory style="display: none;" nwworkingdir="<%= Settings.databaseLocation %>" />
             </span>
             <div class="btns advanced database import-database">
               <div class="btn-settings database">
                 <label class="import-database" for="importdatabase"  title="<%= i18n.__("Open File to Import") %>"><%= i18n.__("Import Database") %></label>
-                <i class="fa fa-level-down">&nbsp;&nbsp;</i>
+                <i class="fa fa-level-down-alt">&nbsp;&nbsp;</i>
                 <input type="file" id="importdatabase"  accept=".zip" style="display:none">
               </div>
               <div class="btn-settings database export-database">
                 <label class="export-database" for="exportdatabase" title="<%= i18n.__("Browse Directoy to save to") %>" ><%= i18n.__("Export Database") %></label>
-                <i class="fa fa-level-up">&nbsp;&nbsp;</i>
+                <i class="fa fa-level-up-alt">&nbsp;&nbsp;</i>
                 <input type="file" id="exportdatabase" style="display:none" nwdirectory>
                         </div>
 

--- a/src/app/templates/torrent_collection.tpl
+++ b/src/app/templates/torrent_collection.tpl
@@ -60,8 +60,8 @@
                    <% } else { %>
                         <div class="item-icon magnet-icon tooltipped" data-toogle="tooltip" data-placement="right" title="<%=i18n.__("Magnet link") %>"></div>
                     <% } %>
-                        <i class="fa fa-trash-o item-delete tooltipped" data-toggle="tooltip" data-placement="left" title="<%= i18n.__("Remove this torrent") %>"></i>
-                        <i class="fa fa-pencil item-rename tooltipped" data-toggle="tooltip" data-placement="left" title="<%= i18n.__("Rename this torrent") %>"></i>
+                        <i class="fa fa-trash item-delete tooltipped" data-toggle="tooltip" data-placement="left" title="<%= i18n.__("Remove this torrent") %>"></i>
+                        <i class="fa fa-pencil-alt item-rename tooltipped" data-toggle="tooltip" data-placement="left" title="<%= i18n.__("Rename this torrent") %>"></i>
                         </a>
                     </li>
                 <% }); %>
@@ -78,9 +78,9 @@
 
         <div class="collection-actions">
             <div class="collection-paste fa fa-paste tooltipped" data-toggle="tooltip" data-placement="left" title="<%= i18n.__("Paste a Magnet link") %>"></div>
-            <div class="collection-import fa fa-level-down tooltipped" data-toggle="tooltip" data-placement="left" title="<%= i18n.__("Import a Torrent file") %>"></div>
+            <div class="collection-import fa fa-level-down-alt tooltipped" data-toggle="tooltip" data-placement="left" title="<%= i18n.__("Import a Torrent file") %>"></div>
             <input class="collection-import-hidden" style="display:none" type="file" accept=".torrent"/>
-            <div class="collection-open fa fa-folder-open-o tooltipped" data-toggle="tooltip" data-placement="left" title="<%= i18n.__("Open Collection Directory") %>"></div>
+            <div class="collection-open fa fa-folder-open tooltipped" data-toggle="tooltip" data-placement="left" title="<%= i18n.__("Open Collection Directory") %>"></div>
         </div>
     </div>
 </div>


### PR DESCRIPTION
* Fix hiding the navigation filters
(the 'genre' and 'sort by' when in the Torrent Collection or Seedbox)

* Fix fontawesome
(https://github.com/popcorn-official/popcorn-desktop/pull/1623/commits/a553d20f5e2a5b4540de9c7b0f64e836d3f05c0a broke some icons)

* Update the keyboard shorcuts help
('ctrl+tab_number' goes up to 'ctrl+4' now with Favorites becoming a tab)

* Fix 'Cast' tooltip styling
(https://github.com/popcorn-official/popcorn-desktop/pull/1623/commits/b0bcc9256bba971b54fbf10158ff8a2d37af3011 caused their template styling to be ignored)

* Stop play-control from moving
(when overview is big enough to have overflow)

* Fix health tooltip's linebreaks

* Remove infoHash top dir for cache files/folders
(spoke with @ivan1986 who first introduced it, he also thinks we should be ok without it, so overall the change makes for a cleaner and easier to navigate cache folder, especially for people who have 'delete cache on exit' disabled and a lot of items cached)

* Tidied up settings-container.tpl