### PR TITLE
Fix 'Watch now' button from idling when bad health torrent

### DIFF
--- a/src/app/lib/streamer.js
+++ b/src/app/lib/streamer.js
@@ -407,7 +407,6 @@
             this.updateStatsInterval = setInterval(this.streamInfo.updateStats.bind(this.streamInfo), 1000);
             this.streamInfo.updateInfos();
             this.torrentModel.on('change', this.streamInfo.updateInfos.bind(this.streamInfo));
-            return App.vent.trigger('stream:started', this.stateModel);
         },
 
         // dummy element to fire stream:start
@@ -450,6 +449,7 @@
                 show_controls: false,
                 streamInfo: this.streamInfo
             });
+            App.vent.trigger('stream:started', this.stateModel);
         },
 
         watchState: function () {

--- a/src/app/templates/loading.tpl
+++ b/src/app/templates/loading.tpl
@@ -1,5 +1,5 @@
 <div class="loading">
-  <div class="loading-backdrop"></div>
+  <div class="loading-backdrop" style="background-image:url( <%= backdrop %> )"></div>
   <div class="loading-backdrop-overlay"></div>
 
     <div class="state-flex">

--- a/src/app/templates/loading.tpl
+++ b/src/app/templates/loading.tpl
@@ -1,5 +1,5 @@
 <div class="loading">
-  <div class="loading-backdrop" style="background-image:url( <%= backdrop %> )"></div>
+  <div class="loading-backdrop" <% try { %> style="background-image:url( <%= backdrop %> )" <% }catch(err) {} %>></div>
   <div class="loading-backdrop-overlay"></div>
 
     <div class="state-flex">


### PR DESCRIPTION
* Fix 'Watch now' button from idling when bad health torrent
that delays to (or cant) resolve