### PR TITLE
Option to disable the Seedbox

### DIFF
--- a/src/app/lib/streamer.js
+++ b/src/app/lib/streamer.js
@@ -121,15 +121,20 @@
                 // update ratio
                 AdvSettings.set('totalDownloaded', Settings.totalDownloaded + this.downloaded);
                 AdvSettings.set('totalUploaded', Settings.totalUploaded + this.uploaded);
-                this.torrent.pause();
-                // complete fause torrent, stop download data
-                for (const id in this.torrent._peers) {
-                  this.torrent.removePeer(id);
-                }
 
-                this.torrent._xsRequests.forEach(req => {
-                  req.abort();
-                });
+                if (Settings.activateSeedbox) {
+                    this.torrent.pause();
+                    // complete fause torrent, stop download data
+                    for (const id in this.torrent._peers) {
+                      this.torrent.removePeer(id);
+                    }
+
+                    this.torrent._xsRequests.forEach(req => {
+                      req.abort();
+                    });
+                } else {
+                    this.torrent.destroy();
+                }
             }
 
             if (this.video) {

--- a/src/app/lib/subtitle/generic.js
+++ b/src/app/lib/subtitle/generic.js
@@ -29,7 +29,7 @@
             var vname = path.basename(vpath).substring(0, path.basename(vpath).lastIndexOf(vext)); // video file name
             var folder = path.dirname(vpath); // cwd
             var furl = data.url; // subtitle url
-            var fpath = path.join(folder, vname + '.' + streamInfo.get("defaultSubtitle").substr(0,streamInfo.get("defaultSubtitle").indexOf('|'))); // subtitle local path, no extension
+            var fpath = path.join(folder, vname + '.' + streamInfo.get("defaultSubtitle").substr(0,2)); // subtitle local path, no extension
 
             request.get(furl).on('response', function (response) {
                 var rtype = (response.headers['content-type'] || '').split(';')[0].trim(); // response type

--- a/src/app/lib/subtitle/generic.js
+++ b/src/app/lib/subtitle/generic.js
@@ -29,7 +29,7 @@
             var vname = path.basename(vpath).substring(0, path.basename(vpath).lastIndexOf(vext)); // video file name
             var folder = path.dirname(vpath); // cwd
             var furl = data.url; // subtitle url
-            var fpath = path.join(folder, vname + '.' + streamInfo.get("defaultSubtitle")); // subtitle local path, no extension
+            var fpath = path.join(folder, vname + '.' + streamInfo.get("defaultSubtitle").substr(0,streamInfo.get("defaultSubtitle").indexOf('|'))); // subtitle local path, no extension
 
             request.get(furl).on('response', function (response) {
                 var rtype = (response.headers['content-type'] || '').split(';')[0].trim(); // response type

--- a/src/app/lib/views/lang_dropdown.js
+++ b/src/app/lib/views/lang_dropdown.js
@@ -58,7 +58,11 @@
         setLang: function (value) {
             console.log(value);
             this.model.set('selected', value);
-            this.ui.selected.removeClass().addClass('flag toggle selected-lang').addClass(value);
+            if (value !== 'none') {
+                this.ui.selected.removeClass().addClass('flag toggle selected-lang').addClass(value.substr(0,2));
+            } else {
+                this.ui.selected.removeClass().addClass('flag toggle selected-lang').addClass(value);
+            }
             App.vent.trigger(this.type + ':lang', value);
         },
 

--- a/src/app/lib/views/settings_container.js
+++ b/src/app/lib/views/settings_container.js
@@ -253,6 +253,7 @@
                 case 'alwaysFullscreen':
                 case 'minimizeToTray':
                 case 'activateTorrentCollection':
+                case 'activateSeedbox':
                 case 'activateWatchlist':
                 case 'activateTempf':
                 case 'opensubtitlesAutoUpload':
@@ -399,6 +400,7 @@
                     break;
                 case 'activateWatchlist':
                 case 'activateTempf':
+                case 'activateSeedbox':
                     App.vent.trigger('movies:list');
                     App.vent.trigger('settings:show');
                     break;

--- a/src/app/lib/views/settings_container.js
+++ b/src/app/lib/views/settings_container.js
@@ -258,6 +258,7 @@
                 case 'activateTempf':
                 case 'opensubtitlesAutoUpload':
                 case 'subtitles_bold':
+                case 'multipleExtSubtitles':
                 case 'rememberFilters':
                 case 'animeTabDisable':
                     value = field.is(':checked');
@@ -401,6 +402,7 @@
                 case 'activateWatchlist':
                 case 'activateTempf':
                 case 'activateSeedbox':
+                case 'multipleExtSubtitles':
                     App.vent.trigger('movies:list');
                     App.vent.trigger('settings:show');
                     break;

--- a/src/app/settings.js
+++ b/src/app/settings.js
@@ -158,6 +158,7 @@ Settings.subtitle_size = '38px';
 Settings.subtitle_color = '#ffffff';
 Settings.subtitle_decoration = 'Outline';
 Settings.subtitle_font = 'Arial';
+Settings.multipleExtSubtitles = false;
 
 // More options
 Settings.httpApiEnabled = false;

--- a/src/app/settings.js
+++ b/src/app/settings.js
@@ -200,6 +200,7 @@ Settings.bigPicture = 100;
 Settings.activateTorrentCollection = true;
 Settings.activateWatchlist = true;
 Settings.activateTempf = true;
+Settings.activateSeedbox = true;
 Settings.onlineSearchEngine = 'ExtraTorrent';
 Settings.enableThepiratebaySearch = true;
 Settings.enable1337xSearch = true;

--- a/src/app/templates/browser/filter-bar.tpl
+++ b/src/app/templates/browser/filter-bar.tpl
@@ -82,7 +82,11 @@
     </li>
 
     <!-- Seedbox -->
-    <li>
+    <% if (Settings.activateSeedbox) { %>
+    <li style="display:block">
+    <% } else { %>
+    <li style="display:none">
+    <% } %>
         <i id="filterbar-seedbox" class="fa fa-download about tooltipped" data-toggle="tooltip" data-placement="bottom" title="<%= i18n.__("Seedbox") %>"></i>
     </li>
 

--- a/src/app/templates/lang-dropdown.tpl
+++ b/src/app/templates/lang-dropdown.tpl
@@ -13,7 +13,7 @@
                     <% if(lang.indexOf('|')!==-1) continue; %>
                 <% } %>
                 <% if(lang !== 'none') { %>
-                    <div class="flag-icon flag <%= lang.substr(0,2) %> tooltipped" data-toggle="tooltip" data-placement="top" data-lang="<%= lang %>" title="<%= App.Localization.nativeName(lang.substr(0,2)) + ' ' + lang.substr(3,1) %>"></div>
+                    <div class="flag-icon flag <%= lang.substr(0,2) %> tooltipped" data-toggle="tooltip" data-placement="top" data-lang="<%= lang %>" title="<%= App.Localization.nativeName(lang.substr(0,2)) + ' ' + lang.substr(3) %>"></div>
                 <% } else { %>
                     <div class="flag-icon flag <%= lang %> tooltipped" data-toggle="tooltip" data-placement="top" data-lang="<%= lang %>" title="<%= App.Localization.nativeName(lang) %>"></div>
                 <% } %>

--- a/src/app/templates/lang-dropdown.tpl
+++ b/src/app/templates/lang-dropdown.tpl
@@ -7,8 +7,16 @@
     <div class="dropdown-menu" role="menu">
         <div class="flag-container">
             <% for(var lang in values){ %>
-            <%   if(lang.indexOf('|')!==-1) continue; %>
-            <div class="flag-icon flag <%= lang %> tooltipped" data-toggle="tooltip" data-placement="top" data-lang="<%= lang %>" title="<%= App.Localization.nativeName(lang) %>"></div>
+                <% if(Settings.multipleExtSubtitles) { %>
+                    <% if(lang.indexOf('|')!==-1 && lang.substr(0,2) !== Settings.subtitle_language) continue; %>
+                <% } else { %>
+                    <% if(lang.indexOf('|')!==-1) continue; %>
+                <% } %>
+                <% if(lang !== 'none') { %>
+                    <div class="flag-icon flag <%= lang.substr(0,2) %> tooltipped" data-toggle="tooltip" data-placement="top" data-lang="<%= lang %>" title="<%= App.Localization.nativeName(lang.substr(0,2)) + ' ' + lang.substr(3,1) %>"></div>
+                <% } else { %>
+                    <div class="flag-icon flag <%= lang %> tooltipped" data-toggle="tooltip" data-placement="top" data-lang="<%= lang %>" title="<%= App.Localization.nativeName(lang) %>"></div>
+                <% } %>
             <% } %>
         </div>
     </div>

--- a/src/app/templates/play-control.tpl
+++ b/src/app/templates/play-control.tpl
@@ -9,7 +9,9 @@
         <div class="row">
             <div id="player-chooser"   class="play-selector"></div>
             <div id="watch-trailer"    class="button play-selector"><%=i18n.__("Watch Trailer") %></div>
+            <% if (Settings.activateSeedbox) { %>
             <div id="download-torrent"    class="button play-selector"><%=i18n.__("Download") %></div>
+            <% } %>
             <div id="quality-selector" class="quality-selector"></div>
         </div>
     </div>

--- a/src/app/templates/settings-container.tpl
+++ b/src/app/templates/settings-container.tpl
@@ -548,10 +548,12 @@
                 <input class="settings-checkbox" name="continueSeedingOnStart" id="continueSeedingOnStart" type="checkbox" <%=(Settings.continueSeedingOnStart? "checked='checked'":"")%>>
                 <label class="settings-label" for="continueSeedingOnStart"><%= i18n.__("Continue seeding torrents after restart app?") %></label>
             </span>
+            <% if (Settings.activateSeedbox) { %>
             <span>
                 <p><%= i18n.__("Maximum number of active torrents") %></p>
                 <input id="maxActiveTorrents" type="number" name="maxActiveTorrents" value="<%=Settings.maxActiveTorrents%>"/>
             </span>
+            <% } %>
         </div>
     </section>
 

--- a/src/app/templates/settings-container.tpl
+++ b/src/app/templates/settings-container.tpl
@@ -420,6 +420,10 @@
                 <label class="settings-label" for="activateTorrentCollection"><%= i18n.__("Torrent Collection") %></label>
             </span>
             <span>
+                <input class="settings-checkbox" name="activateSeedbox" id="activateSeedbox" type="checkbox" <%=(Settings.activateSeedbox? "checked='checked'":"")%>>
+                <label class="settings-label" for="activateSeedbox"><%= i18n.__("Seedbox") %></label>
+            </span>
+            <span>
                 <input class="settings-checkbox" name="activateTempf" id="activateTempf" type="checkbox" <%=(Settings.activateTempf? "checked='checked'":"")%>>
                 <label class="settings-label" for="activateTempf"><%= i18n.__("Cache Folder Button") %></label>
             </span>

--- a/src/app/templates/settings-container.tpl
+++ b/src/app/templates/settings-container.tpl
@@ -260,6 +260,10 @@
                 <input class="settings-checkbox" name="subtitles_bold" id="subsbold" type="checkbox" <%=(Settings.subtitles_bold? "checked='checked'":"")%>>
                 <label class="settings-label" for="subsbold"><%= i18n.__("Bold") %></label>
             </span>
+            <span>
+                <input class="settings-checkbox" name="multipleExtSubtitles" id="multipleExtSubtitles" type="checkbox" <%=(Settings.multipleExtSubtitles? "checked='checked'":"")%>>
+                <label class="settings-label" for="multipleExtSubtitles"><%= i18n.__("Show all available subtitles for the default subtitle language in the flag dropdown menu") %></label>
+            </span>
         </div>
     </section>
 

--- a/src/app/templates/show-detail.tpl
+++ b/src/app/templates/show-detail.tpl
@@ -100,7 +100,9 @@
                 <div class="sdow-watchnow">
                     <div id="player-chooser"></div>
                 </div>
+                <% if (Settings.activateSeedbox) { %>
                 <div id="download-torrent" class="button play-selector"><%=i18n.__("Download") %></div>
+                <% } %>
             </div>
         </div>
     </section>


### PR DESCRIPTION
* Added an option to enable/disable the Seedbox in the settings, which when disabled..

•&nbsp;Removes the Seedbox button from the filterbar
•&nbsp;`.destroy()`'s the torrent instead of `.pause()` + `removePeers()` when the user cancels/stops a stream
•&nbsp;Removes the 'Download' button in the movie/episode detail view
•&nbsp;The last 2 above make it so by definition multiple active torrents aren't possible, as it should (hence the 'Maximum number of active torrents' option is also hidden in the settings) 

*&nbsp;It wont delete any cache files in either case ofc, nothing changed there. The disabled-Seedbox behavior is the same as Popcorn Time's pre-Seedbox behavior.
**&nbsp;The default option remains for the Seedbox to be enabled, as it should imo its a good feature. But.. I think everyone will agree having the choice is even better.

&nbsp;

* Added a 'Show all available subtitles for the default subtitle language in the flag dropdown menu' option in the settings
(for being able to select multiple subtitles for external players, & it will pre-select the subtitle for the native player too, e.g if you select English 5, thats what is going to be selected when the native player opens)

*&nbsp;Its disabled by default and whoever needs it can enable it. Its visible even when advanced settings arent enabled.