### PR TITLE
Get rid of some errors & fix external & Torrent Collection magnet links/.torrent's

### DIFF
--- a/src/app/lib/streamer.js
+++ b/src/app/lib/streamer.js
@@ -310,6 +310,10 @@
 
             var fileName = this.torrentModel.get('video_file').name;
 
+            if (this.torrentModel) {
+                this.torrentModel.set('title', fileName); 
+            }
+
             App.Trakt.client.matcher.match({
                 filename: fileName,
                 torrent: torrent.name
@@ -348,12 +352,12 @@
                 this.handleSubtitles();
 
             }.bind(this)).catch(function(err) {
-                win.error('An error occured while trying to get metadata', err);
                 if (this.torrentModel) {
                     this.torrentModel.set('title', fileName);
                 }
                 this.handleSubtitles();
             }.bind(this));
+            setTimeout(() => { if (!this.subtitleReady) { this.handleSubtitles(); }}, 20000);
         },
 
         // set video file name & index
@@ -653,6 +657,7 @@
                     }
                 }.bind(this));
 
+            setTimeout(() => { if (!this.subtitleReady) { this.subtitleReady = true; }}, 20000);
             return;
         },
 

--- a/src/app/lib/views/main_window.js
+++ b/src/app/lib/views/main_window.js
@@ -511,7 +511,7 @@
 
     showFileSelector: function(fileModel) {
       App.vent.trigger('about:close');
-      App.vent.trigger('stream:stop');
+      App.vent.trigger('stream:stopFS');
       App.vent.trigger('player:close');
       this.showChildView(
         'FileSelector',

--- a/src/app/lib/views/player/loading.js
+++ b/src/app/lib/views/player/loading.js
@@ -200,12 +200,14 @@
       win.info('Loading torrent:', state);
 
       this.ui.stateTextDownload.text(i18n.__(state));
-      if (streamInfo.get('src') && Settings.ipAddress) {
-        this.ui.stateTextStreamUrl.text(streamInfo.get('src').replace('127.0.0.1', Settings.ipAddress));
+      if (streamInfo) {
+        if (streamInfo.get('src') && Settings.ipAddress) {
+          this.ui.stateTextStreamUrl.text(streamInfo.get('src').replace('127.0.0.1', Settings.ipAddress));
+        }
+        this.ui.stateTextFilename.text(streamInfo.get('filename'));
+        this.ui.stateTextSize.text(Common.fileSize(streamInfo.get('size')));
+        this.ui.stateTextDownloadedFormatted.text(Common.fileSize(streamInfo.get('downloaded')) + ' / ');
       }
-      this.ui.stateTextFilename.text(streamInfo.get('filename'));
-      this.ui.stateTextSize.text(Common.fileSize(streamInfo.get('size')));
-      this.ui.stateTextDownloadedFormatted.text(Common.fileSize(streamInfo.get('downloaded')) + ' / ');
       this.listenTo(this.model.get('streamInfo'), 'change', this.onInfosUpdate);
 
       if (state === 'downloading') {

--- a/src/app/lib/views/seedbox.js
+++ b/src/app/lib/views/seedbox.js
@@ -241,7 +241,7 @@
 		    const torrent = this.getTorrentFromEvent(e);
 		    if (torrent) {
 				torrent.destroy(() => {
-					fs.unlinkSync(path.join(torrentsDir, torrent.infoHash));
+					try { fs.unlinkSync(path.join(torrentsDir, torrent.infoHash)); } catch(err) {}
 					rimraf(path.join(App.settings.tmpLocation, torrent.name), () => {
 					});
 				});
@@ -277,7 +277,7 @@
 			}
 
 			const infoHash = $elem.attr('id');
-			const stats = fs.statSync(App.settings.tmpLocation + '/TorrentCache/' + infoHash);
+			try { const stats = fs.statSync(App.settings.tmpLocation + '/TorrentCache/' + infoHash); } catch(err) {}
 			const torrent = App.WebTorrent.get(infoHash);
 
 			if (wasJustSelected) {
@@ -290,7 +290,7 @@
 			$('.seedbox-infos-title').text(torrent.name);
 			$('.seedbox-downloaded').text(' ' + formatBytes(torrent.downloaded));
 			$('.seedbox-uploaded').text(' ' + formatBytes(torrent.uploaded));
-			$('.seedbox-infos-date').text(stats.ctime);
+			try { $('.seedbox-infos-date').text(stats.ctime); } catch(err) {}
 			$('.progress-bar').css('width', (torrent.progress * 100).toFixed(2) + '%');
 			$('.progress-percentage>span').text((torrent.progress * 100).toFixed(2) + '%');
 


### PR DESCRIPTION
* Get rid of some streamer/loading screen/seedbox errors
(all of them happened in very specific circumstances/use cases, and most didnt really do anything other than spam the console, still.. better to just fix and avoid them completely)

* Fix external & Torrent Collection magnet links/.torrent's
(some were getting stuck at 'Connecting' because the stop() function between the torrent selection/paste/drag&drop and the file_selector screen was removing all their peers..)

* Prevent the `lookForMetadata()` and (fetch)`handleSubtitles()` functions run for an undetermined amount of time
(they were basically running until they resolved or error'ed out, no actual timeout or anything. 20 seconds is more than enough for each of them, especially for the `lookForMetadata()` function. Beats getting stuck at connecting for 3 minutes up to forever just because it cant find the title or id or something, depending on the situation..)