### PR TITLE
Fix UI scaling / old Big Picture mode

### DIFF
--- a/src/app/lib/views/browser/generic_browser.js
+++ b/src/app/lib/views/browser/generic_browser.js
@@ -52,14 +52,14 @@
             if (!isNaN(startupTime)) {
                 win.debug('Butter %s startup time: %sms', Settings.version, (window.performance.now() - startupTime).toFixed(3)); // started in database.js;
                 startupTime = 'none';
-                if ((AdvSettings.get('bigPicture') == null) || (AdvSettings.get('bigPicture') == false)) {
+                if (!parseInt(AdvSettings.get('bigPicture'))) {
                     AdvSettings.set('bigPicture', 100);
                 }
-                if ((!AdvSettings.get('disclaimerAccepted')) && (ScreenResolution.QuadHD)) {
+                if (!AdvSettings.get('disclaimerAccepted') && ScreenResolution.QuadHD) {
                     AdvSettings.set('bigPicture', 140);
                     win.zoomLevel = Math.log(1.4) / Math.log(1.2);
                 }
-                if (AdvSettings.get('bigPicture') != 100) {
+                if (AdvSettings.get('bigPicture') != 100 && parseInt(AdvSettings.get('bigPicture'))) {
                     win.zoomLevel = Math.log(AdvSettings.get('bigPicture')/100) / Math.log(1.2);
                 }
                 App.vent.trigger('app:started');


### PR DESCRIPTION
* Fix UI scaling / old Big Picture mode

It caused the UI to crash if you updated Popcorn Time without resetting your settings (or a clean install) if at some point you had changed 'Big picture mode' and became true/false like it use to be instead of a number 25-400* like it is now with 'UI scaling'. 
This fixes it it will automatically change anything that's not a number to 100 (default value) and will continue normally from there.

*&nbsp;Users cant change this option to something else than a number or less than 25% / more than 400% from the settings page so as to not break the UI to a point they cant recover from/see the option to revert it anymore. They can however change this to a smaller/bigger value by manually editing the settings file. We could easily reset ([L55](https://github.com/popcorn-official/popcorn-desktop/pull/1656/files#diff-4dbe64fc9edd5b1a2e317c65840af2bdR55)) and/or block ([L62](https://github.com/popcorn-official/popcorn-desktop/pull/1656/files#diff-4dbe64fc9edd5b1a2e317c65840af2bdR62)) this also but I guess keeping this freedom for extraordinary cases is a plus so I'm leaving it to still be possible.