### PR TITLE
Fix UI scaling / old Big Picture mode

### DIFF
--- a/src/app/lib/views/browser/generic_browser.js
+++ b/src/app/lib/views/browser/generic_browser.js
@@ -52,15 +52,20 @@
             if (!isNaN(startupTime)) {
                 win.debug('Butter %s startup time: %sms', Settings.version, (window.performance.now() - startupTime).toFixed(3)); // started in database.js;
                 startupTime = 'none';
-                if ((AdvSettings.get('bigPicture') == null) || (AdvSettings.get('bigPicture') == false)) {
-                    AdvSettings.set('bigPicture', 100);
-                }
-                if ((!AdvSettings.get('disclaimerAccepted')) && (ScreenResolution.QuadHD)) {
-                    AdvSettings.set('bigPicture', 140);
-                    win.zoomLevel = Math.log(1.4) / Math.log(1.2);
-                }
-                if (AdvSettings.get('bigPicture') != 100) {
-                    win.zoomLevel = Math.log(AdvSettings.get('bigPicture')/100) / Math.log(1.2);
+                if (parseInt(AdvSettings.get('bigPicture'))) {
+                    if (AdvSettings.get('bigPicture') != 100) {
+                        win.zoomLevel = Math.log(AdvSettings.get('bigPicture')/100) / Math.log(1.2);
+                    } else if (!AdvSettings.get('disclaimerAccepted') && ScreenResolution.QuadHD) {
+                        AdvSettings.set('bigPicture', 140);
+                        win.zoomLevel = Math.log(1.4) / Math.log(1.2);
+                    }
+                } else {
+                    if (ScreenResolution.QuadHD) {
+                        AdvSettings.set('bigPicture', 140);
+                        win.zoomLevel = Math.log(1.4) / Math.log(1.2);
+                    } else {
+                        AdvSettings.set('bigPicture', 100);
+                    }
                 }
                 App.vent.trigger('app:started');
             }


### PR DESCRIPTION
* Fix UI scaling / old Big Picture mode

It caused the UI to crash if you updated Popcorn Time without resetting your settings (or a clean install) if at some point you had changed 'Big picture mode' and became true/false like it use to be instead of a number 25-400 (%) like it is now with 'UI scaling'. 
This fixes it it will automatically change anything that's not a number to the default value and will continue normally from there.

(*it looks more complex/messy but after the first run it will only go through [L55-L56](https://github.com/popcorn-official/popcorn-desktop/pull/1658/files#diff-4dbe64fc9edd5b1a2e317c65840af2bdR55-R56) & [L58](https://github.com/popcorn-official/popcorn-desktop/pull/1658/files#diff-4dbe64fc9edd5b1a2e317c65840af2bdR58) if you have UI scaling set to 100% and [L55-L57](https://github.com/popcorn-official/popcorn-desktop/pull/1658/files#diff-4dbe64fc9edd5b1a2e317c65840af2bdR55-R57) if its anything else from the 25-400 range while before it would just run through all the separate if conditions consecutively, ..not that a couple of if's more matter but, better removing a couple than adding a couple, especially since this is at startup)