### PR TITLE
Add an 'Export Database' button in the 'Update now' popup notification

### DIFF
--- a/src/app/language/en.json
+++ b/src/app/language/en.json
@@ -489,5 +489,7 @@
 	"Custom API Server": "Custom API Server",
 	"Proxy Server": "Proxy Server",
 	"comedy": "comedy",
-	"musical": "musical"
+	"musical": "musical",
+	"Remember to Export your Database before updating if you would like to be able to restore your Favorites, marked as watched and settings": "Remember to Export your Database before updating if you would like to be able to restore your Favorites, marked as watched and settings",
+	"Update Now": "Update Now"
 }

--- a/src/app/updater.js
+++ b/src/app/updater.js
@@ -214,12 +214,12 @@
 
                 App.vent.trigger('notification:show', new App.Model.Notification({
                     title: 'Update ' + (updateData.version || 'Hotfix') + ' Installed',
-                    body: (updateData.description + '<p style="font-size:75%;opacity:0.75">* Remember to Export your Database before updating if you would like to be able to restore your Favorites, marked as watched and settings</font>' || 'Auto update'),
+                    body: (updateData.description + '<p style="font-size:75%;opacity:0.75">* ' + i18n.__('Remember to Export your Database before updating if you would like to be able to restore your Favorites, marked as watched and settings') + '</font>' || 'Auto update'),
                     showRestart: false,
                     type: 'info',
                     buttons: [
-                        { title: '<label class="export-database" for="exportdatabase">Export Database</label>' + '<input type="file" id="exportdatabase" style="display:none" nwdirectory="">', action: backupDB },
-                        { title: 'Update Now', action: startWinUpdate }
+                        { title: '<label class="export-database" for="exportdatabase">' + i18n.__('Export Database') + '</label>' + '<input type="file" id="exportdatabase" style="display:none" nwdirectory="">', action: backupDB },
+                        { title: i18n.__('Update Now'), action: startWinUpdate }
                     ]
                 }));
                 win.on('close', function () {

--- a/src/app/updater.js
+++ b/src/app/updater.js
@@ -191,15 +191,36 @@
                     win.close(true);
                 };
 
+                var backupDB = function () {
+                    var zip = new AdmZip();
+                    var databaseFiles = fs.readdirSync(App.settings['databaseLocation']);
+                    var fileinput = document.querySelector('input[id=exportdatabase]');
+
+                    $('#exportdatabase').on('change', function () {
+                        var path = fileinput.value;
+                        try {
+                            databaseFiles.forEach(function (entry) {
+                                zip.addLocalFile(App.settings['databaseLocation'] + '/' + entry);
+                            });
+                            fs.writeFile(path + '/database.zip', zip.toBuffer(), function (err) {
+                                this.alertMessageWait(i18n.__('Exporting Database...'));
+                                win.info('Database exported to:', path);
+                            });
+                        } catch (err) {
+                            console.log(err);
+                        }
+                    });
+                };
+
                 App.vent.trigger('notification:show', new App.Model.Notification({
                     title: 'Update ' + (updateData.version || 'Hotfix') + ' Installed',
-                    body: (updateData.description || 'Auto update'),
+                    body: (updateData.description + '<p style="font-size:75%;opacity:0.75">* Remember to Export your Database before updating if you would like to be able to restore your Favorites, marked as watched and settings</font>' || 'Auto update'),
                     showRestart: false,
                     type: 'info',
-                    buttons: [{
-                        title: 'Update Now',
-                        action: startWinUpdate
-                    }]
+                    buttons: [
+                        { title: '<label class="export-database" for="exportdatabase">Export Database</label>' + '<input type="file" id="exportdatabase" style="display:none" nwdirectory="">', action: backupDB },
+                        { title: 'Update Now', action: startWinUpdate }
+                    ]
                 }));
                 win.on('close', function () {
                     startWinUpdate();


### PR DESCRIPTION
Adds an 'Export Database' button in the 'Update now' popup notification and some text to notify users to backup their databases before they update in case they get deleted during the process

Screenshot:
![screen](https://user-images.githubusercontent.com/38388670/92290658-886a9d80-ef1d-11ea-9d7d-773028d8ac84.png)