### PR TITLE
Fix adding custom subtitles in the native player

### DIFF
--- a/src/app/vendor/videojshooks.js
+++ b/src/app/vendor/videojshooks.js
@@ -280,7 +280,7 @@ vjs.TextTrack.prototype.load = function () {
 
         // Handles charset encoding
         var decode = function (dataBuff, language, callback) {
-            if(language.indexOf('|')!==-1){
+            if(language && language.indexOf('|')!==-1){
                 language = language.substr(0,language.indexOf('|'));
             }
 


### PR DESCRIPTION
https://github.com/popcorn-official/popcorn-desktop/pull/1545 made it so it was producing a "cant read indexOf undefined" error when you tried to add custom subtitles in the native player and the subtitles were never added