### PR TITLE
Switch to multiple issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,3 +1,12 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: ''
+labels: ''
+assignees: ''
+
+---
+
 Operating System Version:
 <!-- OS X 10.11? Windows 10? Linux?-->
 
@@ -25,5 +34,5 @@ Download url (optional):
 2. ...
 3. ...
 
-#### Screenshot of error from developer console (optional)
+#### Screenshot of error from developer console (F12 key (win & linux) or ⌘+⌥+i (macOS), then 'console' tab) (optional)
 <!-- Screenshot helps with finding why stuff breaks -->

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,20 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+**Describe the idea you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.

--- a/.github/ISSUE_TEMPLATE/missing_content.md
+++ b/.github/ISSUE_TEMPLATE/missing_content.md
@@ -1,0 +1,12 @@
+---
+name: Missing or wrong movie / episode
+about: Do not open an issue
+title: Do not open an issue
+labels: wontfix
+assignees: ''
+
+---
+
+The app don't manage the content. Results comes from third parties APIs.
+
+This is useless to open an issue here for those kind of issues.


### PR DESCRIPTION
Switching to multiple issue templates, 

so eventually will help to reduce unnecessary issue about missing content to start with.

I took inspiration from https://github.com/popcorn-official/popcorn-android