### PR TITLE
Replace special chars in search with a space

### DIFF
--- a/src/app/lib/views/browser/filter_bar.js
+++ b/src/app/lib/views/browser/filter_bar.js
@@ -253,9 +253,9 @@
       App.vent.trigger('seedbox:close');
       App.vent.trigger('movie:closeDetail');
       e.preventDefault();
-      var searchvalue = this.ui.searchInput.val();
+      var searchvalue = this.ui.searchInput.val().replace(/[^a-zA-Z0-9]/g,' ');
       this.model.set({
-        keywords: this.ui.searchInput.val(),
+        keywords: this.ui.searchInput.val().replace(/[^a-zA-Z0-9]/g,' '),
         genre: ''
       });
 


### PR DESCRIPTION
Since the search box already wont accept special characters and just ignores them _(e.g Scooby-Doo -> ScoobyDoo, Les Misérables -> Les Misrables, Bob's Burgers -> Bobs Burgers etc)_ which creates a situation that results in 0 hits, and the solution to this is basically to just replace the special character with a space, why not just do it in code without needing anything from the user?

(please someone review this in case you think there is a better place for it or if it shouldn't be done for some reason I'm missing)

*fixes https://github.com/popcorn-official/popcorn-desktop/issues/1514