### PR TITLE
Prevent requiring to restart after cache dir change

### DIFF
--- a/src/app/lib/views/seedbox.js
+++ b/src/app/lib/views/seedbox.js
@@ -35,6 +35,7 @@
 
 		initialize: function () {
 			if (!fs.existsSync(torrentsDir)) {
+				torrentsDir = path.join(App.settings.tmpLocation + '/TorrentCache/');
 				fs.mkdirSync(torrentsDir);
 				console.debug('Seedbox: data directory created');
 			}


### PR DESCRIPTION
..for the Seedbox tab to work again

*fixes https://github.com/popcorn-official/popcorn-desktop/issues/1555