### PR TITLE
Prevent requiring to restart after cache dir change

### DIFF
--- a/src/app/lib/views/seedbox.js
+++ b/src/app/lib/views/seedbox.js
@@ -34,6 +34,7 @@
 		},
 
 		initialize: function () {
+			torrentsDir = path.join(App.settings.tmpLocation + '/TorrentCache/');
 			if (!fs.existsSync(torrentsDir)) {
 				fs.mkdirSync(torrentsDir);
 				console.debug('Seedbox: data directory created');


### PR DESCRIPTION
..for the Seedbox tab to work again

*fixes https://github.com/popcorn-official/popcorn-desktop/issues/1555