### PR TITLE
Fix oversized background after subtitle reload

### DIFF
--- a/src/app/vendor/videojshooks.js
+++ b/src/app/vendor/videojshooks.js
@@ -399,6 +399,7 @@ vjs.TextTrackMenuItem.prototype.onClick = function () {
 
 vjs.TextTrackMenuItem.prototype.update = function () {
     this.selected(this.track.mode() === 2);
+    $('.vjs-text-track').css('display', 'inline-block');
 };
 
 vjs.Player.prototype.onLoadStart = function () {


### PR DESCRIPTION
*fixes https://github.com/popcorn-official/popcorn-desktop/issues/1713

The default `display` is 'none', we change it to 'inline-block' to show the subtitles, but then when the subtitle is reloaded a second time it changes to 'block' instead which causes the oversize issue. I cant find anything that sets this to 'block' I think its the videojs module and we just need to set it to 'inline-block' again which we never do except for the first time. Now it does that whenever a different subtitle is selected.

@Persei08 can you please test this if it works as intended on your end? thanks!