### PR TITLE
Fix oversized background after subtitle reload

### DIFF
--- a/src/app/vendor/videojshooks.js
+++ b/src/app/vendor/videojshooks.js
@@ -395,6 +395,7 @@ vjs.TextTrackMenuItem = vjs.MenuItem.extend({
 vjs.TextTrackMenuItem.prototype.onClick = function () {
     vjs.MenuItem.prototype.onClick.call(this);
     this.player_.showTextTrack(this.track.id_, this.track.kind());
+    $('.vjs-text-track').css('display', 'inline-block');
 };
 
 vjs.TextTrackMenuItem.prototype.update = function () {


### PR DESCRIPTION
*fixes https://github.com/popcorn-official/popcorn-desktop/issues/1713

The [default `display` value](https://github.com/popcorn-official/popcorn-desktop/blob/development/src/app/styl/views/videojs.styl#L744) is 'none' and we [change it](https://github.com/popcorn-official/popcorn-desktop/blob/development/src/app/vendor/videojshooks.js#L93)  to 'inline-block' to show the subtitles, but then when the same subtitle is reloaded a second time it changes to 'block' instead which causes the oversize issue. I cant find anything that sets this to 'block' (I think its the video.js module) so we probably just need to set it to 'inline-block' again, which we never do [except for the first time](https://github.com/popcorn-official/popcorn-desktop/blob/development/src/app/vendor/videojshooks.js#L84).

Now it will do it every time a different subtitle is selected in the popup menu, doesn't matter if it had been loaded before or not.

@Persei08 can you please test this if it works as intended on your end? thanks!