### PR TITLE
Add toggle subtitles keyboard shortcut

### DIFF
--- a/src/app/httpapi.js
+++ b/src/app/httpapi.js
@@ -639,6 +639,11 @@
                 butterCallback(callback);
             });
 
+            server.expose('togglesubtitles', function (args, opt, callback) {
+                Mousetrap.trigger('v');
+                butterCallback(callback);
+            });
+
             server.expose('togglefullscreen', function (args, opt, callback) {
                 Mousetrap.trigger('f');
                 butterCallback(callback, false, {

--- a/src/app/language/en.json
+++ b/src/app/language/en.json
@@ -515,5 +515,6 @@
 	"Download list is empty...": "Download list is empty...",
 	"Maximum number of active torrents": "Maximum number of active torrents",
 	"reality": "reality",
-	"Currently Airing": "Currently Airing"
+	"Currently Airing": "Currently Airing",
+	"Toggle Subtitles": "Toggle Subtitles"
 }

--- a/src/app/lib/views/player/player.js
+++ b/src/app/lib/views/player/player.js
@@ -5,6 +5,7 @@
         template: '#player-tpl',
         className: 'player',
         player: null,
+        prevSub: null,
 
         ui: {
             eyeInfo: '.eye-info-player',
@@ -507,6 +508,15 @@
             }, function () {
                 clearInterval(that._ShowUIonHover);
             });
+            for(let i = 0; i < $('.vjs-menu-item').length; i++) {
+                let curSub = $('.vjs-menu-item')[i];
+                if (!curSub.innerHTML.includes(i18n.__('Disabled'))) {
+                    curSub.onclick = function() {
+                        that.prevSub = this;
+                    }
+                }
+            }
+            this.prevSub = this.model.get('defaultSubtitle') === 'none' && Settings.subtitle_language !== 'none' ? $('.vjs-menu-item:contains("' + App.Localization.langcodes[Settings.subtitle_language].nativeName +'")')[0] || $('.vjs-selected')[0] : $('.vjs-selected')[0];
         },
 
         sendToTrakt: function (method) {
@@ -651,6 +661,10 @@
             Mousetrap.bind('backspace', function (e) {
                 that.closePlayer();
             });
+
+            Mousetrap.bind(['v', 'V'], function (e) {
+                that.subtitlesOnOff();
+            }, 'keydown');
 
             Mousetrap.bind(['f', 'F'], function (e) {
                 that.toggleFullscreen();
@@ -803,6 +817,8 @@
 
             Mousetrap.unbind('backspace');
 
+            Mousetrap.unbind(['v', 'V']);
+
             Mousetrap.unbind(['f', 'F']);
 
             Mousetrap.unbind('h');
@@ -906,6 +922,12 @@
 
         toggleMute: function () {
             this.player.muted(!this.player.muted());
+        },
+
+        subtitlesOnOff: function () {
+            $('.vjs-selected')[0].innerHTML.includes(i18n.__('Disabled')) ? this.prevSub.click() : $('.vjs-menu-item')[0].click();
+            this.displayOverlayMsg(i18n.__('Subtitles') + ': ' + i18n.__($(".vjs-selected")[0].innerHTML));
+            $('.vjs-overlay').css('opacity', '1');
         },
 
         toggleFullscreen: function () {

--- a/src/app/templates/keyboard.tpl
+++ b/src/app/templates/keyboard.tpl
@@ -201,6 +201,10 @@
                         <td><%= i18n.__("Toggle Mute") %></td>
                     </tr>
                     <tr>
+                        <td><span class="key">v</span></td>
+                        <td><%= i18n.__("Toggle Subtitles") %></td>
+                    </tr>
+                    <tr>
                         <td><span class="key">h</span></td>
                         <td><%= i18n.__("Offset Subtitles by") %> +0.1s</td>
                     </tr>


### PR DESCRIPTION
Added `V` as a keyboard shortcut that toggles the subtitles on and off in the native player.

*fixes https://github.com/popcorn-official/popcorn-desktop/issues/966