### PR TITLE
Add Crop to Fit screen keyboard shortcut & titlebar fullscreen bug fix

### DIFF
--- a/src/app/app.js
+++ b/src/app/app.js
@@ -193,6 +193,10 @@ var initApp = function () {
   } catch (e) {
     console.error('Couldn\'t start app: ', e, e.stack);
   }
+
+  if (localStorage.maximized === 'true') {
+    win.maximize();
+  }
 };
 
 App.onStart = function (options) {
@@ -284,10 +288,12 @@ win.on('leave-fullscreen', function () {
 
 win.on('maximize', function () {
   win.setResizable(false);
+  localStorage.maximized = true;
 });
 
 win.on('restore', function () {
   win.setResizable(true);
+  localStorage.maximized = false;
 });
 
 // Now this function is used via global keys (cmd+q and alt+f4)

--- a/src/app/httpapi.js
+++ b/src/app/httpapi.js
@@ -639,6 +639,11 @@
                 butterCallback(callback);
             });
 
+            server.expose('togglecroptofit', function (args, opt, callback) {
+                Mousetrap.trigger('c');
+                butterCallback(callback);
+            });
+
             server.expose('togglesubtitles', function (args, opt, callback) {
                 Mousetrap.trigger('v');
                 butterCallback(callback);

--- a/src/app/language/en.json
+++ b/src/app/language/en.json
@@ -516,5 +516,9 @@
 	"Maximum number of active torrents": "Maximum number of active torrents",
 	"reality": "reality",
 	"Currently Airing": "Currently Airing",
-	"Toggle Subtitles": "Toggle Subtitles"
+	"Toggle Subtitles": "Toggle Subtitles",
+	"Toggle Crop to Fit screen": "Toggle Crop to Fit screen",
+	"Original": "Original",
+	"Fit screen": "Fit screen",
+	"Video already fits screen": "Video already fits screen"
 }

--- a/src/app/lib/views/player/player.js
+++ b/src/app/lib/views/player/player.js
@@ -662,6 +662,10 @@
                 that.closePlayer();
             });
 
+            Mousetrap.bind(['c', 'C'], function (e) {
+                that.toggleCrop();
+            }, 'keydown');
+
             Mousetrap.bind(['v', 'V'], function (e) {
                 that.subtitlesOnOff();
             }, 'keydown');
@@ -817,6 +821,8 @@
 
             Mousetrap.unbind('backspace');
 
+            Mousetrap.unbind(['c', 'C']);
+
             Mousetrap.unbind(['v', 'V']);
 
             Mousetrap.unbind(['f', 'F']);
@@ -922,6 +928,26 @@
 
         toggleMute: function () {
             this.player.muted(!this.player.muted());
+        },
+
+        toggleCrop: function () {
+            var curVideo = $('#video_player_html5_api');
+            if (curVideo[0]) {
+                var multPer = ((curVideo[0].videoWidth / curVideo[0].videoHeight) / (screen.width / screen.height))*100;
+                if (curVideo.width() > $('#video_player').width() || curVideo.height() > $('#video_player').height()) {
+                    curVideo.css({'width': '100%', 'height': '100%', 'left': '0', 'top': '0'});
+                    this.displayOverlayMsg(i18n.__('Original'));
+                } else if (multPer > 100) {
+                    curVideo.css({'width': multPer + '%', 'left': 50-multPer/2 + '%'});
+                    this.displayOverlayMsg(i18n.__('Fit screen'));
+                } else if (multPer < 100) {
+                    curVideo.css({'height': 10000/multPer + '%', 'top': 50-5000/multPer + '%'});
+                    this.displayOverlayMsg(i18n.__('Fit screen'));
+                } else {
+                    this.displayOverlayMsg(i18n.__('Video already fits screen'));
+                }
+                $('.vjs-overlay').css('opacity', '1');
+            }
         },
 
         subtitlesOnOff: function () {

--- a/src/app/lib/views/title_bar.js
+++ b/src/app/lib/views/title_bar.js
@@ -85,11 +85,6 @@
 
         toggleFullscreen: function () {
             win.toggleFullscreen();
-            if (this.nativeWindow.isFullscreen) {
-                $('.os-min, .os-max').css('display', 'none');
-            } else {
-                $('.os-min, .os-max').css('display', 'block');
-            }
             this.$el.find('.btn-os.fullscreen').toggleClass('active');
         },
 

--- a/src/app/templates/keyboard.tpl
+++ b/src/app/templates/keyboard.tpl
@@ -201,6 +201,10 @@
                         <td><%= i18n.__("Toggle Mute") %></td>
                     </tr>
                     <tr>
+                        <td><span class="key">c</span></td>
+                        <td><%= i18n.__("Toggle Crop to Fit screen") %></td>
+                    </tr>
+                    <tr>
                         <td><span class="key">v</span></td>
                         <td><%= i18n.__("Toggle Subtitles") %></td>
                     </tr>


### PR DESCRIPTION
- Added `C` as a keyboard shortcut that toggles cropping to fit the screen on and off in the native player.

- Prevent removing the maximize and minimize buttons on app fullscreen for macOS and Linux.
*fixes #1542 
(on Windows they are already not being removed and they dont break anything UI-wise, better than having them disappear and requiring to restart the app to get them back)

- Remember maximized/not maximized window state