### PR TITLE
Prevent unbinding of keyboard shortcuts when a notification is displayed

### DIFF
--- a/src/app/lib/views/movie_detail.js
+++ b/src/app/lib/views/movie_detail.js
@@ -61,7 +61,7 @@
 
       //If a child was added above this view
       App.vent.on('viewstack:push', function() {
-        if (_.last(App.ViewStack) !== _this.className) {
+        if (_.last(App.ViewStack) !== _this.className && _.last(App.ViewStack) !== 'notificationWrapper') {
           _this.unbindKeyboardShortcuts();
         }
       });

--- a/src/app/lib/views/player/loading.js
+++ b/src/app/lib/views/player/loading.js
@@ -79,14 +79,14 @@
 
       //If a child was removed from above this view
       App.vent.on('viewstack:pop', function() {
-        if (_.last(App.ViewStack) === that.className && _.last(App.ViewStack) !== 'notificationWrapper') {
+        if (_.last(App.ViewStack) === that.className) {
           that.initKeyboardShortcuts();
         }
       });
 
       //If a child was added above this view
       App.vent.on('viewstack:push', function() {
-        if (_.last(App.ViewStack) !== that.className) {
+        if (_.last(App.ViewStack) !== that.className && _.last(App.ViewStack) !== 'notificationWrapper') {
           that.unbindKeyboardShortcuts();
         }
       });

--- a/src/app/lib/views/player/loading.js
+++ b/src/app/lib/views/player/loading.js
@@ -79,7 +79,7 @@
 
       //If a child was removed from above this view
       App.vent.on('viewstack:pop', function() {
-        if (_.last(App.ViewStack) === that.className) {
+        if (_.last(App.ViewStack) === that.className && _.last(App.ViewStack) !== 'notificationWrapper') {
           that.initKeyboardShortcuts();
         }
       });

--- a/src/app/lib/views/show_detail.js
+++ b/src/app/lib/views/show_detail.js
@@ -74,7 +74,7 @@
 
             //If a child was added above this view
             App.vent.on('viewstack:push', function () {
-                if (_.last(App.ViewStack) !== _this.className) {
+                if (_.last(App.ViewStack) !== _this.className && _.last(App.ViewStack) !== 'notificationWrapper') {
                     _this.unbindKeyboardShortcuts();
                 }
             });


### PR DESCRIPTION
Now it will exclude notifications from when unbinding keyboard shortcuts because of a view that has been pushed in the viewstack. No reason to do that for notifications, you still basically remain in the same view you were before and they dont even bind/unbind any keyboard shortcuts of their own. Why mess with the keyboard bindings because of one to begin with.

*fixes https://github.com/popcorn-official/popcorn-desktop/issues/1013 and probably other situations where this issue was manifesting but went unnoticed
(though the only views I could find that have this are _movie_detail_, _show_detail_ and _loading_, so.. them and anything that came 'after' them was affected, e.g the player)