### PR TITLE
Prevent unbinding of keyboard shortcuts when a notification is displayed

### DIFF
--- a/src/app/lib/views/browser/list.js
+++ b/src/app/lib/views/browser/list.js
@@ -261,7 +261,7 @@
 
             Mousetrap.bind('i', function () {
                 if ((App.PlayerView === undefined || App.PlayerView.isDestroyed) && $('#player').children().length <= 0) {
-                    $('.about').click();
+                    $('#filterbar-about').click();
                 }
             }, 'keydown');
 

--- a/src/app/lib/views/browser/list.js
+++ b/src/app/lib/views/browser/list.js
@@ -255,7 +255,7 @@
 
             Mousetrap.bind(['`', 'b'], function () {
                 if ((App.PlayerView === undefined || App.PlayerView.isDestroyed) && $('#about-container').children().length <= 0 && $('#player').children().length <= 0) {
-                    $('.favorites').click();
+                    $('#filterbar-favorites').click();
                 }
             }, 'keydown');
 

--- a/src/app/lib/views/movie_detail.js
+++ b/src/app/lib/views/movie_detail.js
@@ -61,7 +61,7 @@
 
       //If a child was added above this view
       App.vent.on('viewstack:push', function() {
-        if (_.last(App.ViewStack) !== _this.className) {
+        if (_.last(App.ViewStack) !== _this.className && _.last(App.ViewStack) !== 'notificationWrapper') {
           _this.unbindKeyboardShortcuts();
         }
       });

--- a/src/app/lib/views/player/loading.js
+++ b/src/app/lib/views/player/loading.js
@@ -86,7 +86,7 @@
 
       //If a child was added above this view
       App.vent.on('viewstack:push', function() {
-        if (_.last(App.ViewStack) !== that.className) {
+        if (_.last(App.ViewStack) !== that.className && _.last(App.ViewStack) !== 'notificationWrapper') {
           that.unbindKeyboardShortcuts();
         }
       });

--- a/src/app/lib/views/player/player.js
+++ b/src/app/lib/views/player/player.js
@@ -1,6 +1,7 @@
 (function (App) {
     'use strict';
 
+    var _this;
     var Player = Marionette.View.extend({
         template: '#player-tpl',
         className: 'player',
@@ -30,6 +31,7 @@
         },
 
         initialize: function () {
+            _this = this;
             this.listenTo(this.model, 'change:downloadSpeed', this.updateDownloadSpeed);
             this.listenTo(this.model, 'change:uploadSpeed', this.updateUploadSpeed);
             this.listenTo(this.model, 'change:active_peers', this.updateActivePeers);
@@ -43,6 +45,13 @@
             this.firstPlay = true;
 
             this.boundedMouseScroll = this.mouseScroll.bind(this);
+
+            //If a child was removed from above this view
+            App.vent.on('viewstack:pop', function() {
+              if (_.last(App.ViewStack) === 'app-overlay') {
+                _this.bindKeyboardShortcuts();
+              }
+            });
         },
 
         isMovie: function () {

--- a/src/app/lib/views/player/player.js
+++ b/src/app/lib/views/player/player.js
@@ -763,10 +763,6 @@
                 that.toggleMute();
             }, 'keydown');
 
-            Mousetrap.bind(['u', 'U'], function (e) {
-                that.displayStreamURL();
-            }, 'keydown');
-
             Mousetrap.bind('j', function (e) {
                 that.adjustPlaybackRate(-0.1, true);
             }, 'keydown');
@@ -876,8 +872,6 @@
 
             Mousetrap.unbind(['m', 'M']);
 
-            Mousetrap.unbind(['u', 'U']);
-
             Mousetrap.unbind(['j', 'shift+j', 'ctrl+j']);
 
             Mousetrap.unbind(['k', 'shift+k', 'ctrl+k']);
@@ -973,12 +967,6 @@
 
         moveSubtitles: function (e) {
             AdvSettings.set('playerSubPosition', $('.vjs-text-track').css('top'));
-        },
-
-        displayStreamURL: function () {
-            var clipboard = nw.Clipboard.get();
-            clipboard.set($('#video_player video').attr('src'), 'text');
-            this.displayOverlayMsg(i18n.__('URL of this stream was copied to the clipboard'));
         },
 
         adjustSubtitleOffset: function (s) {

--- a/src/app/lib/views/show_detail.js
+++ b/src/app/lib/views/show_detail.js
@@ -74,7 +74,7 @@
 
             //If a child was added above this view
             App.vent.on('viewstack:push', function () {
-                if (_.last(App.ViewStack) !== _this.className) {
+                if (_.last(App.ViewStack) !== _this.className && _.last(App.ViewStack) !== 'notificationWrapper') {
                     _this.unbindKeyboardShortcuts();
                 }
             });

--- a/src/app/templates/keyboard.tpl
+++ b/src/app/templates/keyboard.tpl
@@ -257,10 +257,6 @@
                         <td><%= i18n.__('Set playback rate to %s', '4x') %></td>
                     </tr>
                     <tr>
-                        <td><span class="key">u</span></td>
-                        <td><%= i18n.__("Show Stream URL") %></td>
-                    </tr>
-                    <tr>
                         <td><span class="key">1</span></td>
                         <td><%= i18n.__("Set player window to video resolution") %></td>
                     </tr>


### PR DESCRIPTION
* Prevent unbinding of keyboard shortcuts when a notification is displayed
*&nbsp;Now it will exclude notifications from when unbinding keyboard shortcuts because of a view that has been pushed in the viewstack. No reason to do that for notifications, you still basically remain in the same view you were before and they don't even bind/unbind any keyboard shortcuts of their own. Why mess with the keyboard bindings because of one to begin with.
*&nbsp;fixes https://github.com/popcorn-official/popcorn-desktop/issues/1013 and probably other situations where this issue was manifesting but went unnoticed
(though the only views I could find that have this are _movie_detail_, _show_detail_ and _loading_, so.. anything that came 'after' them was affected, e.g the player)

* Rebind player keyboard shortcuts when a child view is removed from above it
Even though this is no longer needed for notifications it might be needed for other child views (e.g keyboard help / `?`). _movie_detail_, _show_detail_ and _loading_ are already doing it for themselves but they cant do it for the player they bind different shortcuts.

* Remove obsolete/non-working `U` player keyboard shortcut
It did copy the stream url to the clipboard but gave no indication it did so or not for a long time now.
But since the stream url is always visible in the 'eye' popup (also for some time now) and clicking/right-clicking the icon also already copies the filename/stream url to the clipboard having a keyboard shortcut doing (half)the same job and with a totally different function nonetheless seems somewhat unnecessary clutter.

* Fix About/`I` keyboard shortcut
It also launched the Seedbox and cache folder due to the same class name, now it clicks by id which is unique.

* Fix Favorites/`B` (and ` ) keyboard shortcut
Same as above it was clicking by class name and when Favorites were made into a tab it broke. Changed it to the id as well.