### PR TITLE
More accurate volume bar when adjusting with the mouse

### DIFF
--- a/src/app/lib/views/player/player.js
+++ b/src/app/lib/views/player/player.js
@@ -924,7 +924,7 @@
 
         adjustVolume: function (i) {
             var v = this.player.volume();
-            this.player.volume(v + i);
+            this.player.volume((v + i).toFixed(1));
             App.vent.trigger('volumechange');
             $('.vjs-overlay').css('opacity', '1');
         },

--- a/src/app/vendor/videojshooks.js
+++ b/src/app/vendor/videojshooks.js
@@ -446,7 +446,7 @@ vjs.Player.prototype.volume = function (percentAsDecimal) {
 
         //let's save this bad boy
         AdvSettings.set('playerVolume', vol.toFixed(1));
-        App.PlayerView.displayOverlayMsg(i18n.__('Volume') + ': ' + vol.toFixed(1) * 100 + '%');
+        App.PlayerView.displayOverlayMsg(i18n.__('Volume') + ': ' + (vol.toFixed(2) * 100).toFixed(0) + '%');
 
         return this;
     }


### PR DESCRIPTION
It was still adjusting the volume by 1% increments when adjusting with the mouse before but the overlay notification wasn't showing it. It only showed increments of 10. Now it shows the exact volume. 
(nothing changed when adjusting with the keyboard or scroll wheel, they still adjust in increments of 10/whatever they were before, e.g if you set it at 76% with the mouse and scroll down it will become 70% etc)