### PR TITLE
Volume overlay fix

### DIFF
--- a/src/app/lib/views/player/player.js
+++ b/src/app/lib/views/player/player.js
@@ -932,7 +932,6 @@
                 this.player.volume((v2 - 0.1).toFixed(1));
             }
             App.vent.trigger('volumechange');
-            $('.vjs-overlay').css('opacity', '1');
         },
 
         toggleMute: function () {

--- a/src/app/vendor/videojshooks.js
+++ b/src/app/vendor/videojshooks.js
@@ -440,9 +440,6 @@ vjs.Player.prototype.volume = function (percentAsDecimal) {
         this.cache_.volume = vol;
         this.techCall('setVolume', vol);
         vjs.setLocalStorage('volume', vol);
-        if ($('.vjs-overlay')) {
-            $('.vjs-overlay').css('opacity', '1');
-        }
 
         //let's save this bad boy
         AdvSettings.set('playerVolume', vol.toFixed(1));
@@ -453,6 +450,11 @@ vjs.Player.prototype.volume = function (percentAsDecimal) {
 
     // Default to 1 when returning current volume.
     vol = parseFloat(this.techGet('volume'));
+
+    if ($('.vjs-overlay')) {
+        $('.vjs-overlay').css('opacity', '1');
+    }
+
     return (isNaN(vol)) ? 1 : vol;
 };
 


### PR DESCRIPTION
We only need one of them to set the overlay's opacity and they were messing each other up a bit (a timer is started to set it back to 0 once set to 1 by something). The one in videojshooks is the one that remains since it also applies to when adjusting from the UI.