### PR TITLE
List performance optimizations

### DIFF
--- a/src/app/lib/views/browser/list.js
+++ b/src/app/lib/views/browser/list.js
@@ -1,7 +1,6 @@
 (function (App) {
     'use strict';
 
-    var SCROLL_MORE = 0.7; // 70% of window height
     var NUM_MOVIES_IN_ROW = 7;
     var _this;
 
@@ -410,16 +409,15 @@
                 ghostsToAdd--;
             }
         },
+
         onScroll: function () {
             if (!this.collection.hasMore) {
                 return;
             }
 
-            var totalHeight = this.$el.prop('scrollHeight');
-            var currentPosition = this.$el.scrollTop() + this.$el.height();
+            var viewsToBottom = (this.$el.prop('scrollHeight') - this.$el.scrollTop()) / this.$el.height();
 
-            if (this.collection.state === 'loaded' &&
-                (currentPosition / totalHeight) > SCROLL_MORE) {
+            if (this.collection.state === 'loaded' && viewsToBottom < 3) {
                 this.collection.fetchMore();
             }
         },

--- a/src/app/styl/views/browser/item.styl
+++ b/src/app/styl/views/browser/item.styl
@@ -137,7 +137,7 @@
                 border 2px solid $PosterHoverBorder
                 transition border-color .50s
                 opacity: 1
-                will-change transform
+                will-change: transform
     .title
         height: auto;
         margin: 6px 0 4px;

--- a/src/app/styl/views/browser/item.styl
+++ b/src/app/styl/views/browser/item.styl
@@ -32,6 +32,7 @@
             position absolute
             transition opacity 500ms ease-in
             opacity 0
+            will-change opacity
 
             &img
                 position absolute
@@ -136,6 +137,7 @@
                 border 2px solid $PosterHoverBorder
                 transition border-color .50s
                 opacity: 1
+                will-change transform
     .title
         height: auto;
         margin: 6px 0 4px;

--- a/src/app/styl/views/browser/list.styl
+++ b/src/app/styl/views/browser/list.styl
@@ -74,6 +74,7 @@
         align-content: flex-start
         align-items: flex-start
         width: calc(100% - 5px)
+        will-change: transform, scroll-position
 
     .error
         font-size: 1.5em;


### PR DESCRIPTION
* Change `fetchMore()` API call condition from scroll percentage to absolute value
  Now it will make a call for more items when you have less than 2*window.height to reach the end of the list instead of if you are below 70% of the total list height that it was before.
  *fixes https://github.com/popcorn-official/popcorn-desktop/issues/1734#issuecomment-706275878

* Improve list & list item performance with `will-change` CSS property

&nbsp;

(Can everyone with time to do so please test this? Does it help with list and UI scrolling performance at your end? Any suggestions?)