### PR TITLE
Fix list up/down keyboard navigation

### DIFF
--- a/src/app/lib/views/browser/list.js
+++ b/src/app/lib/views/browser/list.js
@@ -480,9 +480,14 @@
             itemSelected.removeClass('selected');
             item.eq(index).addClass('selected');
 
-            var $movieEl = itemSelected[0];
+            var $movieEl = item[index];
             if (!elementInViewport(this.$el, $movieEl)) {
-                $movieEl.scrollIntoView(false);
+                if (itemSelected.index() > index) {
+                    $movieEl.scrollIntoView(true);
+                    document.getElementsByClassName('list')[0].scrollTop -= 75;
+                } else if (itemSelected.index() < index) {
+                    $movieEl.scrollIntoView(false);
+                }
                 this.onScroll();
             }
         },


### PR DESCRIPTION
`↓` went 2 rows below the screenview before the view moved 1 row down, so the selected item was never visible. 
As for `↑`, it was going a whole page up instead of going 1 row up like `↓` does.

Now both go 1 row up/down and the selected item is always visible.