### PR TITLE
Rebind list keyboard shortcuts when view removed from above it

### DIFF
--- a/src/app/lib/views/browser/list.js
+++ b/src/app/lib/views/browser/list.js
@@ -264,6 +264,11 @@
                 }
             }, 'keydown');
 
+            App.vent.on('viewstack:pop', function() {
+                if (_.last(App.ViewStack) === 'init-container') {
+                    _this.initKeyboardShortcuts();
+                }
+            });
         },
 
         initPosterResizeKeys: function () {


### PR DESCRIPTION
Some views (e.g Show detail) are unbinding keyboard shortcuts that the list view also uses when you exit them. This rebinds them.