### PR TITLE
Try to fetch missing list view cover images from TMDb

### DIFF
--- a/src/app/lib/views/browser/item.js
+++ b/src/app/lib/views/browser/item.js
@@ -132,9 +132,34 @@
             var noimg = 'images/posterholder.png';
             var poster = this.model.get('image');
             if (!poster && this.model.get('images') && this.model.get('images').poster){
-            poster = this.model.get('images').poster;
+                poster = this.model.get('images').poster;
+            } else if (this.model.get('poster')) {
+                poster = this.model.get('poster');
             } else {
-            poster = this.model.get('poster') || noimg;
+                var imdb = this.model.get('imdb_id'),
+                api_key = Settings.tmdb.api_key,
+                movie = function () {
+                    var tmp = null;
+                    $.ajax({
+                        url: 'http://api.themoviedb.org/3/movie/' + imdb + '?api_key=' + api_key + '&append_to_response=videos',
+                        type: 'get',
+                        dataType: 'json',
+                        async: false,
+                        global: false,
+                        success: function (data) {
+                            tmp = data;
+                        }
+                    });
+                    return tmp;
+                }();
+                poster = movie && movie.poster_path ? 'http://image.tmdb.org/t/p/w500' + movie.poster_path : noimg;
+                this.model.set('poster', poster);
+                !this.model.get('synopsis') && movie && movie.overview ? this.model.set('synopsis', movie.overview) : null;
+                (!this.model.get('rating') || this.model.get('rating') == '0' || this.model.get('rating') == '0.0') && movie && movie.vote_average ? this.model.set('rating', movie.vote_average) : null;
+                (!this.model.get('runtime') || this.model.get('runtime') == '0') && movie && movie.runtime ? this.model.set('runtime', movie.runtime) : null;
+                !this.model.get('trailer') && movie && movie.videos && movie.videos.results && movie.videos.results[0] ? this.model.set('trailer', 'http://www.youtube.com/watch?v=' + movie.videos.results[0].key) : null;
+                (!this.model.get('backdrop') || this.model.get('backdrop') == 'images/posterholder.png') && movie && movie.backdrop_path ? this.model.set('backdrop', 'http://image.tmdb.org/t/p/w500' + movie.backdrop_path) : ((!this.model.get('backdrop') || this.model.get('backdrop') == 'images/posterholder.png') && movie && movie.poster_path ? this.model.set('backdrop', 'http://image.tmdb.org/t/p/w500' + movie.poster_path) : null);
+                this.model.set('getmetarunned', true);
             }
 
             var setImage = function (img) {

--- a/src/app/lib/views/movie_detail.js
+++ b/src/app/lib/views/movie_detail.js
@@ -46,7 +46,7 @@
       curSynopsis = {old: '', crew: '', cast: '', allcast: '', vstatus: null};
 
       //Check for missing metadata or if Translate Synopsis is enabled and the language set to something other than English and if one, or multiple are true run the corresponding function to try and fetch them
-      if (!this.model.get('synopsis') || !this.model.get('rating') || this.model.get('rating') == '0' || this.model.get('rating') == '0.0' || !this.model.get('runtime') || this.model.get('runtime') == '0' || !this.model.get('trailer') || !this.model.get('poster') || this.model.get('poster') == 'images/posterholder.png' || !this.model.get('backdrop') || this.model.get('backdrop') == 'images/posterholder.png' || (Settings.translateSynopsis && Settings.language != 'en')) {
+      if (((!this.model.get('synopsis') || !this.model.get('rating') || this.model.get('rating') == '0' || this.model.get('rating') == '0.0' || !this.model.get('runtime') || this.model.get('runtime') == '0' || !this.model.get('trailer') || !this.model.get('poster') || this.model.get('poster') == 'images/posterholder.png' || !this.model.get('backdrop') || this.model.get('backdrop') == 'images/posterholder.png') && !this.model.get('getmetarunned')) || (Settings.translateSynopsis && Settings.language != 'en')) {
         this.getMetaData();
       }
       


### PR DESCRIPTION
Last added - [before](https://user-images.githubusercontent.com/38388670/98454199-82d24380-216a-11eb-9b54-a51efa17c4bc.jpg), [after](https://user-images.githubusercontent.com/38388670/98454201-8796f780-216a-11eb-9674-04f4fb963898.jpg)
Rating - [before](https://user-images.githubusercontent.com/38388670/98454203-8a91e800-216a-11eb-9e76-8a729a39c71d.jpg), [after](https://user-images.githubusercontent.com/38388670/98454205-8bc31500-216a-11eb-86ae-3207137a2c9d.jpg)
Random search - [before](https://user-images.githubusercontent.com/38388670/98454206-8ebe0580-216a-11eb-8955-206c1acf88e8.jpg), [after](https://user-images.githubusercontent.com/38388670/98454207-8fef3280-216a-11eb-8e8a-b471534d5092.jpg)

Since the performance issues the list had are now resolved (this doesnt really cause a measurable performance hit too) and since there is a significant number of missing cover images maybe this is a solution, even if temporary and can be removed at some point when something like this gets implemented in a better location (e.g the API). And even then maybe it could work as a redundancy, it will only try to fetch missing covers it doesnt run at all when a cover image already exists (like the one in movie_detail did so far)

Also added a condition to said existing `getMetaData()` function in the movie_detail view to not repeat for no reason if a TMDb call has already been made for that item by the list view due to a missing cover. All the fetched meta is already set on the model and passed on to the movie_detail view and whatever else uses them.

As for what TMDb has to say about this.. apparently there is no issue. They had a very generous 40 calls / 10 seconds limit which is way more than enough for what we need, which in 2019 they made into unlimited (https://developers.themoviedb.org/3/getting-started/request-rate-limiting) and even in the rare occasion they flag someone for abuse or put a timeout on him this is being done by IP not API key (https://www.themoviedb.org/talk/5b592d95c3a36801da00402a), which means apps like Popcorn Time can use it in use cases like this and more demanding ones.