### PR TITLE
Fix the 'Remember filters' option

### DIFF
--- a/src/app/lib/views/browser/generic_browser.js
+++ b/src/app/lib/views/browser/generic_browser.js
@@ -24,6 +24,10 @@
         initialize: function () {
             this.filter = new App.Model.Filter(this.filters);
 
+            if (Settings.rememberFilters) {
+                this.filter.set(this.getSavedFilter());
+            }
+
             this.collection = new this.collectionModel([], {
                 filter: this.filter
             });
@@ -35,10 +39,6 @@
         },
 
         onAttach: function () {
-            if (Settings.rememberFilters) {
-                this.filter.set(this.getSavedFilter());
-            }
-
             this.bar = new App.View.FilterBar({
                 model: this.filter
             });


### PR DESCRIPTION
It seems it was too late where it was firing in `onAttach`. Moving to `initialize` makes it work as it should again.
(I'm guessing the [Marionette v3 update](https://github.com/popcorn-official/popcorn-desktop/commit/04f23ac1827e371a6842e51f0775d1fab66b8c18#diff-128e76c413489bdce651bf703e3f696cf6cca070720d0a0f870142d5fa3f2b65) had something to do with this?)

*fixes #1476 