### PR TITLE
More 'Start Screen' fixes

### DIFF
--- a/src/app/lib/views/browser/filter_bar.js
+++ b/src/app/lib/views/browser/filter_bar.js
@@ -76,7 +76,7 @@
       var navFilters = $('#nav-filters');
       var filterbarRandom = $('#filterbar-random');
 
-      if (Settings.startScreen === 'Last Open') {
+      if (Settings.startScreen === 'Last Open' && App.currentview !== 'Seedbox') {
         AdvSettings.set('lastTab', set);
       }
 

--- a/src/app/lib/views/settings_container.js
+++ b/src/app/lib/views/settings_container.js
@@ -430,9 +430,9 @@
                     }
                     break;
                 case 'activateWatchlist':
-                   if (AdvSettings.get('startScreen') === 'Watchlist') { 
+                    if (AdvSettings.get('startScreen') === 'Watchlist') { 
                         $('select[name=start_screen]').change();
-                   }
+                    }
                 case 'activateTempf':
                 case 'activateSeedbox':
                 case 'multipleExtSubtitles':

--- a/src/app/lib/views/settings_container.js
+++ b/src/app/lib/views/settings_container.js
@@ -412,6 +412,9 @@
                         App.vent.trigger('torrentCollection:close');
                         App.vent.trigger('seedbox:close');
                     }
+                    if (AdvSettings.get('startScreen') === 'Torrent-collection') { 
+                        $('select[name=start_screen]').change();
+                    }
                     break;
                 case 'animeTabDisable':
                     var animeTab = $('.animeTabShow');
@@ -422,8 +425,14 @@
                         App.vent.trigger('movies:list');
                         App.vent.trigger('settings:show');
                     }
+                    if (AdvSettings.get('startScreen') === 'Anime') { 
+                        $('select[name=start_screen]').change();
+                    }
                     break;
                 case 'activateWatchlist':
+                   if (AdvSettings.get('startScreen') === 'Watchlist') { 
+                        $('select[name=start_screen]').change();
+                   }
                 case 'activateTempf':
                 case 'activateSeedbox':
                 case 'multipleExtSubtitles':


### PR DESCRIPTION
* ~~Prevent Seedbox from bugging the app on start when 'Start Screen' is set to 'Last Open
  (the Seedbox was bugging the app and the filterbar doesnt show when its set as a start screen and the only way to fix it after this was to manually reset your settings)~~
  **EDIT:** This was reverted and fixed properly with #1811, now the Seedbox can be set as a Start Screen also.

* Reset the 'Start Screen' option if the one that its set at gets disabled
  (it will reset to the first view available on the menu)