### PR TITLE
Update Fanart.tv API key

### DIFF
--- a/src/app/settings.js
+++ b/src/app/settings.js
@@ -41,7 +41,7 @@ var Settings = {
     client_secret: 'ghmK6ueMJjQLHBwsaao1tw3HUF7JVp_GQTwDwhCn'
   },
   fanart: {
-    api_key: '8104b601679c3ec23e7d3e4d93ddb46f'
+    api_key: 'ce4bba4b3cc473306c6cddb4e1cb0da4'
   },
   tvdb: {
     api_key: '80A769280C71D83B'


### PR DESCRIPTION
([the old one is from at least 2016]( https://github.com/butterproject/butter-desktop/commit/943444c13aeeda78af3a975ae6c90f9427715dfa) and invalid/expired)