### PR TITLE
Small overview fix

### DIFF
--- a/src/app/styl/views/movie_detail.styl
+++ b/src/app/styl/views/movie_detail.styl
@@ -212,7 +212,6 @@
                 position: relative
                 height: 55%
                 overflow: hidden
-                text-overflow: ellipsis
                 float: none
                 color: #FFF
                 top: 25px


### PR DESCRIPTION
It was sometimes cutting of the last letter on some cast names and replacing it with ellipsis (...) which actually took up more space. There is also no actual need for this, the text is already set to justify and break lines (but not individual words)