### PR TITLE
Prevent 'Maximum call stack size exceeded' error on player fullscreen toggle

### DIFF
--- a/src/app/lib/views/lang_dropdown.js
+++ b/src/app/lib/views/lang_dropdown.js
@@ -56,7 +56,6 @@
         },
 
         setLang: function (value) {
-            console.log(value);
             this.model.set('selected', value);
             if (value !== 'none') {
                 this.ui.selected.removeClass().addClass('flag toggle selected-lang').addClass(value.substr(0,2));

--- a/src/app/vendor/videojshooks.js
+++ b/src/app/vendor/videojshooks.js
@@ -66,6 +66,7 @@ vjs.Player.prototype.listenForUserActivity = function () {
 };
 
 vjs.Player.prototype.onFullscreenChange = function () {
+    e.stopPropagation();
     if (this.isFullscreen()) {
         this.addClass('vjs-fullscreen');
         $('.vjs-text-track').css('font-size', '140%');

--- a/src/app/vendor/videojshooks.js
+++ b/src/app/vendor/videojshooks.js
@@ -65,7 +65,7 @@ vjs.Player.prototype.listenForUserActivity = function () {
     });
 };
 
-vjs.Player.prototype.onFullscreenChange = function () {
+vjs.Player.prototype.onFullscreenChange = function (e) {
     e.stopPropagation();
     if (this.isFullscreen()) {
         this.addClass('vjs-fullscreen');


### PR DESCRIPTION
* Prevent 'Maximum call stack size exceeded' error on player fullscreen toggle
It seems its how the new(ish) v4 videojs behaves (or an error in it) and loops that for about 1 second which, on the pc I was debugging this at least, was enough to run this function about 900 times which in turn causes the maximum call stack error. Unless specifically told not to propagate. *fixes https://github.com/popcorn-official/popcorn-desktop/issues/1743

* Removed a duplicate console log for the lang_dropdown value
There are already console logs for the selected subtitle and audio language which are also correctly labeled to specify what they are in the log e.g `Subtitles: en`. This one just said `en` or whatever language was selected and nothing else.

&nbsp;

@Persei08 I requested a review for the first one. Do the subtitles resize as before on your end? Do you see any issues? Thanks!