### PR TITLE
Fix Windows titlebar buttons in light colored themes

### DIFF
--- a/src/app/styl/Official_-_Black_&_Yellow_theme.styl
+++ b/src/app/styl/Official_-_Black_&_Yellow_theme.styl
@@ -37,6 +37,8 @@
 //Top Bar
     $TitleBarBg = Black
     $TitleBarText = #fff
+    $TbarFilter = none
+    $TbarFilterHov = none
     $FullScreenButton = #999
     $FullScreenButtonHover = YellowL
 

--- a/src/app/styl/Official_-_Dark_theme.styl
+++ b/src/app/styl/Official_-_Dark_theme.styl
@@ -30,6 +30,8 @@
 //Top Bar
     $TitleBarBg = #17181b
     $TitleBarText = #fff
+    $TbarFilter = none
+    $TbarFilterHov = none
     $FullScreenButton = #999
     $FullScreenButtonHover = #b2b2b2
 

--- a/src/app/styl/Official_-_FlaX_theme.styl
+++ b/src/app/styl/Official_-_FlaX_theme.styl
@@ -40,6 +40,8 @@
 //Top Bar
     $TitleBarBg = Green
     $TitleBarText = #fff
+    $TbarFilter = none
+    $TbarFilterHov = none
     $FullScreenButton = #fff
     $FullScreenButtonHover = Rose
 

--- a/src/app/styl/Official_-_Flat_UI_theme.styl
+++ b/src/app/styl/Official_-_Flat_UI_theme.styl
@@ -31,7 +31,7 @@
     $TitleBarBg = #34495e
     $TitleBarText = #fff
     $TbarFilter = brightness(0%)
-    $TbarFilterHov = brightness(100%)
+    $TbarFilterHov = none
     $FullScreenButton = #fff
     $FullScreenButtonHover = #1abc9c
 

--- a/src/app/styl/Official_-_Flat_UI_theme.styl
+++ b/src/app/styl/Official_-_Flat_UI_theme.styl
@@ -30,6 +30,8 @@
 //Top Bar
     $TitleBarBg = #34495e
     $TitleBarText = #fff
+    $TbarFilter = brightness(0%)
+    $TbarFilterHov = brightness(100%)
     $FullScreenButton = #fff
     $FullScreenButtonHover = #1abc9c
 

--- a/src/app/styl/Official_-_High_Contrast_theme.styl
+++ b/src/app/styl/Official_-_High_Contrast_theme.styl
@@ -52,6 +52,8 @@
 //Top Bar
     $TitleBarBg = Black
     $TitleBarText = #fff
+    $TbarFilter = none
+    $TbarFilterHov = none
     $FullScreenButton = #fff
     $FullScreenButtonHover = PurpleL
 

--- a/src/app/styl/Official_-_Light_theme.styl
+++ b/src/app/styl/Official_-_Light_theme.styl
@@ -37,6 +37,8 @@
 //Top Bar
     $TitleBarBg = #fafafa
     $TitleBarText = #000
+    $TbarFilter = brightness(0%)
+    $TbarFilterHov = brightness(100%)
     $FullScreenButton = #3d3d3d
     $FullScreenButtonHover = GreenD
 

--- a/src/app/styl/Official_-_Light_theme.styl
+++ b/src/app/styl/Official_-_Light_theme.styl
@@ -38,7 +38,7 @@
     $TitleBarBg = #fafafa
     $TitleBarText = #000
     $TbarFilter = brightness(0%)
-    $TbarFilterHov = brightness(100%)
+    $TbarFilterHov = none
     $FullScreenButton = #3d3d3d
     $FullScreenButtonHover = GreenD
 

--- a/src/app/styl/Sebastiaans_-_Black_&_Red_theme.styl
+++ b/src/app/styl/Sebastiaans_-_Black_&_Red_theme.styl
@@ -36,6 +36,8 @@
 //Top Bar
     $TitleBarBg = Black  
     $TitleBarText = #fff
+    $TbarFilter = none
+    $TbarFilterHov = none
     $FullScreenButton = #999
     $FullScreenButtonHover = RedL
 

--- a/src/app/styl/views/windows-titlebar.styl
+++ b/src/app/styl/views/windows-titlebar.styl
@@ -78,39 +78,47 @@
 .window-close-icon {
   background: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='11' height='11' viewBox='0 0 11 11' fill='none'%3E%3Cpath d='M6.279 5.5L11 10.221l-.779.779L5.5 6.279.779 11 0 10.221 4.721 5.5 0 .779.779 0 5.5 4.721 10.221 0 11 .779 6.279 5.5z' fill='%23fff'/%3E%3C/svg%3E") no-repeat 50% 50%
   background-size: 10px
+  filter: $TbarFilter
 }
 
 .window-close:hover .window-close-icon {
   background: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='11' height='11' viewBox='0 0 11 11' fill='none'%3E%3Cpath d='M6.279 5.5L11 10.221l-.779.779L5.5 6.279.779 11 0 10.221 4.721 5.5 0 .779.779 0 5.5 4.721 10.221 0 11 .779 6.279 5.5z' fill='%23fff'/%3E%3C/svg%3E") no-repeat 50% 50%
   background-size: 10px
+  filter: $TbarFilterHov
 }
 
 .window-maximize-icon {
   background: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='11' height='11' viewBox='0 0 11 11' fill='none'%3E%3Cpath d='M11 0v11H0V0h11zM9.899 1.101H1.1V9.9h8.8V1.1z' fill='%23fff'/%3E%3C/svg%3E") no-repeat 50% 50%
   background-size: 10px
+  filter: $TbarFilter
 }
 
 .window-maximize:hover .window-maximize-icon {
   background: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='11' height='11' viewBox='0 0 11 11' fill='none'%3E%3Cpath d='M11 0v11H0V0h11zM9.899 1.101H1.1V9.9h8.8V1.1z' fill='%23fff'/%3E%3C/svg%3E") no-repeat 50% 50%
   background-size: 10px
+  filter: $TbarFilterHov
 }
 
 .window-umaximize .window-maximize-icon {
   background: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='11' height='11' viewBox='0 0 11 11' fill='none'%3E%3Cpath d='M11 8.798H8.798V11H0V2.202h2.202V0H11v8.798zm-3.298-5.5h-6.6v6.6h6.6v-6.6zM9.9 1.1H3.298v1.101h5.5v5.5h1.1v-6.6z' fill='%23fff'/%3E%3C/svg%3E") no-repeat 50% 50%
   background-size: 10px
+  filter: $TbarFilter
 }
 
 .window-umaximize:hover .window-maximize-icon {
   background: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='11' height='11' viewBox='0 0 11 11' fill='none'%3E%3Cpath d='M11 8.798H8.798V11H0V2.202h2.202V0H11v8.798zm-3.298-5.5h-6.6v6.6h6.6v-6.6zM9.9 1.1H3.298v1.101h5.5v5.5h1.1v-6.6z' fill='%23fff'/%3E%3C/svg%3E") no-repeat 50% 50%
   background-size: 10px
+  filter: $TbarFilterHov
 }
 
 .window-minimize-icon {
   background: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='11' height='11' viewBox='0 0 11 11' fill='none'%3E%3Cpath d='M11 4.399V5.5H0V4.399h11z' fill='%23fff'/%3E%3C/svg%3E") no-repeat 50% 50%
   background-size: 10px
+  filter: $TbarFilter
 }
 
-.window-minimize:hover, .window-minimize-icon {
+.window-minimize:hover .window-minimize-icon {
   background: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='11' height='11' viewBox='0 0 11 11' fill='none'%3E%3Cpath d='M11 4.399V5.5H0V4.399h11z' fill='%23fff'/%3E%3C/svg%3E") no-repeat 50% 50%
   background-size: 10px
+  filter: $TbarFilterHov
 }


### PR DESCRIPTION
*they were basically white on top of a white background, they are also svg's, hence the CSS ~~brightness~~ invert (replaced with #1826) filters to make them black/visible again (for the 2 light themes, for the rest its just set to none)