### PR TITLE
Apply correct theme colors to Windows titlebar

### DIFF
--- a/src/app/styl/Official_-_FlaX_theme.styl
+++ b/src/app/styl/Official_-_FlaX_theme.styl
@@ -38,7 +38,7 @@
     $ScrollBarThumbHover = Rose
 
 //Top Bar
-    $TitleBarBg = rgba(50, 58, 69, 0)
+    $TitleBarBg = #323a45
     $TitleBarText = #fff
     $TbarIconFilter = none
     $FullScreenButton = #fff

--- a/src/app/styl/Official_-_Flat_UI_theme.styl
+++ b/src/app/styl/Official_-_Flat_UI_theme.styl
@@ -30,7 +30,7 @@
 //Top Bar
     $TitleBarBg = #34495e
     $TitleBarText = #fff
-    $TbarIconFilter = invert(100%)
+    $TbarIconFilter = none
     $FullScreenButton = #fff
     $FullScreenButtonHover = #1abc9c
 

--- a/src/app/styl/Official_-_Flat_UI_theme.styl
+++ b/src/app/styl/Official_-_Flat_UI_theme.styl
@@ -28,7 +28,7 @@
     $ScrollBarThumbHover = #16a085
 
 //Top Bar
-    $TitleBarBg = rgba(52, 73, 94, 0)
+    $TitleBarBg = #34495e
     $TitleBarText = #fff
     $TbarIconFilter = invert(100%)
     $FullScreenButton = #fff

--- a/src/app/styl/views/windows-titlebar.styl
+++ b/src/app/styl/views/windows-titlebar.styl
@@ -6,10 +6,10 @@
   height: 24px
   display: flex
   align-items: center
-  background-color $BgColor1
+  background-color $TitleBarBg
   border-top: 1px solid #000
   font-size: 12px
-  color: $Text1
+  color: $TitleBarText
   font-family: $MainFont
 }
 


### PR DESCRIPTION
Flat_UI theme: [before](https://user-images.githubusercontent.com/38388670/99143699-402bd200-2668-11eb-8e9d-b4c8d4ff5e52.jpg), [after](https://user-images.githubusercontent.com/38388670/99143700-41f59580-2668-11eb-8fe1-b28b3b342503.jpg)
FlaX theme: [before](https://user-images.githubusercontent.com/38388670/99143701-44f08600-2668-11eb-8ce1-24b8d935cc5e.jpg), [after](https://user-images.githubusercontent.com/38388670/99143704-46ba4980-2668-11eb-8f5c-b0b9a96fdc7b.jpg)

The rest of the themes also had the wrong color variables on Windows but it wasnt visible or caused an issue because in these the value of `$BgColor1` is the same as `$TitleBarBg` and `$Text1` as `$TitleBarText`

Either way, now all have the correct color variables set on Windows (`src/app/styl/views/windows-titlebar.styl`) like the other OSes (`src/app/styl/views/title_bar.styl`)

&nbsp;

*This PR also reverts #1827 since its no longer necessary when the colors are as they are supposed to be.