### PR TITLE
Loading view: Fix 'Streaming to ...' info

### DIFF
--- a/src/app/lib/views/player/loading.js
+++ b/src/app/lib/views/player/loading.js
@@ -265,8 +265,8 @@
       if (streamInfo.get('title') !== '') {
         this.ui.title.html(streamInfo.get('title'));
       }
-      if (streamInfo.get('player') && streamInfo.get('player').get('type') !== 'local') {
-        this.ui.player.text(streamInfo.get('player').get('name'));
+      if (streamInfo.get('device') && streamInfo.get('device').get('type') !== 'local') {
+        this.ui.player.text(streamInfo.get('device').get('name'));
         this.ui.streaming.css('visibility', 'visible');
       }
     },


### PR DESCRIPTION
On loading view, "Streaming to (external player or device)" were no
longer displayed.

onInfosUpdate was trying to get values from streamInfo.get('player')
which no longer exist. Now we use streamInfo.get('device') instead

![loading_streaming_to_after](https://user-images.githubusercontent.com/22459458/99395028-24cafc00-28e0-11eb-8183-2b605cc8b4c1.png)
