### PR TITLE
Fix Windows installer/uninstaller failing to save user database

### DIFF
--- a/dist/windows/installer_makensis.nsi
+++ b/dist/windows/installer_makensis.nsi
@@ -431,13 +431,23 @@ SectionEnd
 ; ------------------- ;
 Section "uninstall"
     Call un.isRunning
+    CreateDirectory "$TEMP\app_DT"
+    CreateDirectory "$TEMP\app_TC"
+    CopyFiles "$INSTDIR\User Data\*.*" "$TEMP\app_DT"
+    CopyFiles "$INSTDIR\TorrentCollection\*.*" "$TEMP\app_TC"
     RMDir /r "$INSTDIR"
     RMDir /r "$SMPROGRAMS\${APP_NAME}"
     Delete "$DESKTOP\${APP_NAME}.lnk"
 
-    MessageBox MB_YESNO|MB_ICONQUESTION "$(removeDataFolder)" IDNO NoUninstallData
-        RMDir /r "$LOCALAPPDATA\${DATA_FOLDER}"
-    NoUninstallData:
+    MessageBox MB_YESNO|MB_ICONQUESTION "$(removeDataFolder)" IDYES NoUninstallData
+        CreateDirectory "$INSTDIR"
+        CreateDirectory "$INSTDIR\User Data"
+        CreateDirectory "$INSTDIR\TorrentCollection"
+        CopyFiles "$TEMP\app_DT\*.*" "$INSTDIR\User Data"
+        CopyFiles "$TEMP\app_TC\*.*" "$INSTDIR\TorrentCollection"
+    YesUninstallData:
+        RMDir /r "$TEMP\app_DT"
+        RMDir /r "$TEMP\app_TC"
         DeleteRegKey HKCU "${UNINSTALL_KEY}"
         DeleteRegKey HKCU "Software\Classes\Applications\${APP_NAME}" ;file association
 SectionEnd

--- a/dist/windows/installer_makensis.nsi
+++ b/dist/windows/installer_makensis.nsi
@@ -364,16 +364,16 @@ Section
     ;Save DB
     CreateDirectory "$TEMP\app_DT"
     CreateDirectory "$TEMP\app_TC"
-    CopyFiles "$INSTDIR\data\*.*" "$TEMP\app_DT"
+    CopyFiles "$INSTDIR\User Data\*.*" "$TEMP\app_DT"
     CopyFiles "$INSTDIR\TorrentCollection\*.*" "$TEMP\app_TC"
 
     ;Delete existing install
     RMDir /r "$INSTDIR"
 
     CreateDirectory "$INSTDIR"
-    CreateDirectory "$INSTDIR\data"
+    CreateDirectory "$INSTDIR\User Data"
     CreateDirectory "$INSTDIR\TorrentCollection"
-    CopyFiles "$TEMP\app_DT\*.*" "$INSTDIR\data"
+    CopyFiles "$TEMP\app_DT\*.*" "$INSTDIR\User Data"
     CopyFiles "$TEMP\app_TC\*.*" "$INSTDIR\TorrentCollection"
     RMDir /r "$TEMP\app_DT"
     RMDir /r "$TEMP\app_TC"

--- a/dist/windows/installer_makensis.nsi
+++ b/dist/windows/installer_makensis.nsi
@@ -439,7 +439,7 @@ Section "uninstall"
     RMDir /r "$SMPROGRAMS\${APP_NAME}"
     Delete "$DESKTOP\${APP_NAME}.lnk"
 
-    MessageBox MB_YESNO|MB_ICONQUESTION "$(removeDataFolder)" IDYES NoUninstallData
+    MessageBox MB_YESNO|MB_ICONQUESTION "$(removeDataFolder)" IDYES YesUninstallData
         CreateDirectory "$INSTDIR"
         CreateDirectory "$INSTDIR\User Data"
         CreateDirectory "$INSTDIR\TorrentCollection"

--- a/dist/windows/installer_makensis.nsi
+++ b/dist/windows/installer_makensis.nsi
@@ -364,7 +364,7 @@ Section
     ;Save DB
     CreateDirectory "$TEMP\app_DT"
     CreateDirectory "$TEMP\app_TC"
-    CopyFiles "$INSTDIR\User Data\*.*" "$TEMP\app_DT"
+    CopyFiles "$INSTDIR\User Data\Default\data\*.*" "$TEMP\app_DT"
     CopyFiles "$INSTDIR\TorrentCollection\*.*" "$TEMP\app_TC"
 
     ;Delete existing install
@@ -372,8 +372,10 @@ Section
 
     CreateDirectory "$INSTDIR"
     CreateDirectory "$INSTDIR\User Data"
+    CreateDirectory "$INSTDIR\User Data\Default"
+    CreateDirectory "$INSTDIR\User Data\Default\data"
     CreateDirectory "$INSTDIR\TorrentCollection"
-    CopyFiles "$TEMP\app_DT\*.*" "$INSTDIR\User Data"
+    CopyFiles "$TEMP\app_DT\*.*" "$INSTDIR\User Data\Default\data"
     CopyFiles "$TEMP\app_TC\*.*" "$INSTDIR\TorrentCollection"
     RMDir /r "$TEMP\app_DT"
     RMDir /r "$TEMP\app_TC"
@@ -433,7 +435,7 @@ Section "uninstall"
     Call un.isRunning
     CreateDirectory "$TEMP\app_DT"
     CreateDirectory "$TEMP\app_TC"
-    CopyFiles "$INSTDIR\User Data\*.*" "$TEMP\app_DT"
+    CopyFiles "$INSTDIR\User Data\Default\data\*.*" "$TEMP\app_DT"
     CopyFiles "$INSTDIR\TorrentCollection\*.*" "$TEMP\app_TC"
     RMDir /r "$INSTDIR"
     RMDir /r "$SMPROGRAMS\${APP_NAME}"
@@ -442,8 +444,10 @@ Section "uninstall"
     MessageBox MB_YESNO|MB_ICONQUESTION "$(removeDataFolder)" IDYES YesUninstallData
         CreateDirectory "$INSTDIR"
         CreateDirectory "$INSTDIR\User Data"
+        CreateDirectory "$INSTDIR\User Data\Default"
+        CreateDirectory "$INSTDIR\User Data\Default\data"
         CreateDirectory "$INSTDIR\TorrentCollection"
-        CopyFiles "$TEMP\app_DT\*.*" "$INSTDIR\User Data"
+        CopyFiles "$TEMP\app_DT\*.*" "$INSTDIR\User Data\Default\data"
         CopyFiles "$TEMP\app_TC\*.*" "$INSTDIR\TorrentCollection"
     YesUninstallData:
         RMDir /r "$TEMP\app_DT"


### PR DESCRIPTION
For the installer the relevant commands were pointing to `\data` instead of `\User Data` which is the actual dir

And the uninstaller was clearing the install dir before it tried to save the user data because it assumed `$DATA_FOLDER` and `$INSTDIR` were different directories and not like it actually is which is `$DATA_FOLDER` being a subdir of `$INSTDIR`

fixes #1579 (and maybe #1712 ?)