### PR TITLE
Loading screen improvements

### DIFF
--- a/src/app/lib/views/player/loading.js
+++ b/src/app/lib/views/player/loading.js
@@ -59,9 +59,6 @@
       'click .play': 'resumeStreaming',
       'click .forward': 'forwardStreaming',
       'click .backward': 'backwardStreaming',
-      'click .minimize-icon': 'minDetails',
-      'click .maximize-icon': 'minDetails',
-      'click .maximize-icong': 'minDetails',
       'click .show-pcontrols': 'showpcontrols',
       'mousedown .title': 'titletoclip',
       'mousedown .text_filename': 'filenametoclip',
@@ -148,35 +145,6 @@
       Mousetrap.unbind(['esc', 'backspace']);
     },
 
-    minDetails: function () {
-      var loading = $('.loading');
-      var loadingBackground = $('.loading-background');
-      var minimizeIcon = $('.minimize-icon');
-      var maximizeIcon = $('.maximize-icon');
-      if (minimizeIcon.css('visibility') === 'visible') {
-        loading.css('height', '0px');
-        loading.css('width', '0px');
-        loading.css('float', 'right');
-        loadingBackground.css('visibility', 'hidden');
-        minimizeIcon.css('visibility', 'hidden');
-        if (this.ddone === 'false') {
-          maximizeIcon.css('visibility', 'visible');
-        } else {
-          maximizeIcon.css('visibility', 'visible');
-        }
-        $('.filter-bar').show();
-      } else if ((maximizeIcon.css('visibility') === 'visible') || (maximizeIcon.css('visibility') === 'visible')) {
-        loading.css('height', '100%');
-        loading.css('width', '100%');
-        loading.css('float', '');
-        loadingBackground.css('visibility', 'visible');
-        maximizeIcon.css('visibility', 'hidden');
-        maximizeIcon.css('visibility', 'hidden');
-        minimizeIcon.css('visibility', 'visible');
-        $('.filter-bar').hide();
-      }
-    },
-
     onAttach: function() {
       $('.filter-bar').hide();
       $('#header').addClass('header-shadow');
@@ -184,7 +152,7 @@
       App.LoadingView = this;
 
       this.initKeyboardShortcuts();
-      $('.minimize-icon,#maxic,.open-button,.title,.text_filename,.text_streamurl,.show-pcontrols').tooltip({
+      $('.open-button,.title,.text_filename,.text_streamurl,.show-pcontrols').tooltip({
           html: true,
           delay: {
               'show': 800,
@@ -296,20 +264,9 @@
         $('#ractpr').hide();
         if (this.ddone === 'false') {
           var cancelButton = $('.cancel-button');
-          var maximizeIcon = $('.maximize-icon');
 
           this.ddone = 'true';
           cancelButton.css('background-color', '#27ae60');
-          cancelButton.css('margin-left', '168px');
-          if (Settings.activateLoCtrl === false) {
-            $('.open-button').css('visibility', 'visible').css('display', 'block');
-          } else if (Settings.activateLoCtrl === true) {
-            $('.open-button').css('visibility', 'visible').css('display', 'none');
-          }
-          if (maximizeIcon.css('visibility') === 'visible') {
-            maximizeIcon.css('visibility', 'visible');
-            maximizeIcon.css('visibility', 'hidden');
-          }
           this.listenTo(this.model.get('streamInfo'), 'change:uploadSpeed', this.onProgressUpdate);
         }
       }
@@ -387,14 +344,12 @@
         AdvSettings.set('activateLoCtrl', true);
         $('.show-pcontrols').removeClass('fa-angle-down').addClass('fa-angle-up').tooltip('hide').attr('data-original-title', i18n.__('Hide playback controls'));
         this.ui.cancel_button.css('display', 'none');
-        $('.open-button').css('display', 'none');
         this.ui.controls.css('display', 'block');
         this.ui.playingbarBox.css('display', 'block');
       } else if (Settings.activateLoCtrl === true) {
         AdvSettings.set('activateLoCtrl', false);
         $('.show-pcontrols').removeClass('fa-angle-up').addClass('fa-angle-down').tooltip('hide').attr('data-original-title', i18n.__('Show playback controls'));
         this.ui.cancel_button.css('display', 'block');
-        $('.open-button').css('display', 'block');
         this.ui.controls.css('display', 'none');
         this.ui.playingbarBox.css('display', 'none');
       }

--- a/src/app/styl/views/loading.styl
+++ b/src/app/styl/views/loading.styl
@@ -186,29 +186,16 @@
                 font-size 12px
 
         .open-button
-            visibility hidden
-            z-index 2
+            float right
             cursor pointer
-            width 35px
-            height 35px
-            margin -35px auto auto 297px
-            -moz-border-radius 3px
-            -webkit-border-radius 3px
-            border-radius 3px
-            -moz-background-clip padding
-            -webkit-background-clip padding-box
-            background-clip padding-box
-            background-color #27ae60
-            -webkit-backface-visibility hidden
-            transition all .5s
+            transition opacity .3s
+            opacity 0.3
 
             &:hover
-                background: #27ae60
-                text-decoration: none
+                opacity 1
 
             &:active
-                box-shadow: inset 0 1px 4px rgba(0,0,0,0.6)
-                background: #27ae60
+                opacity 1
 
             .open-button-text
                 -webkit-backface-visibility hidden

--- a/src/app/templates/loading.tpl
+++ b/src/app/templates/loading.tpl
@@ -59,7 +59,8 @@
 
                 <!-- downloading info -->
                 <div class="loading-info">
-                    <span class="buffer_percent"></span>&nbsp;&nbsp;&nbsp;<span class="text">(</span><span class="text_downloadedformatted"><%= Common.fileSize(0) %></span><span class="text_size"><%= Common.fileSize(0) %></span><span class="text">)</span><br>
+                    <span class="buffer_percent"></span>&nbsp;&nbsp;&nbsp;<span class="text">(</span><span class="text_downloadedformatted"><%= Common.fileSize(0) %></span><span class="text_size"><%= Common.fileSize(0) %></span><span class="text">)</span>
+                    <span class="open-button tooltipped" data-toggle="tooltip" data-placement="bottom" title="<%= i18n.__("Cache Folder") %>"><i class="fa fa-folder-open"></i></span><br>
                     <span class="text_remaining"></span><span id="rbreak1" style="line-height:13px;"><br></span><br>
                     <span class="loading-info-text" id="rdownl"><%= i18n.__("Download") %>:&nbsp;</span>
                     <span class="download_speed value"><%= Common.fileSize(0) %>/s</span><span id="rbreak2" style="line-height:13px;"><br></span>
@@ -86,9 +87,6 @@
 
             <div id="cancel-button" class="cancel-button">
                 <div class="cancel-button-text"><%= i18n.__("Cancel") %></div>
-            </div>
-            <div class="open-button tooltipped" data-toggle="tooltip" data-placement="bottom" title="<%= i18n.__("Cache Folder") %>">
-                <div class="open-button-text"><i class="fa fa-folder-open"></i></div>
             </div>
         </div>
     </div>


### PR DESCRIPTION
* Made the 'Cache Folder' button always visible at the top right of the downloading stats box instead of only after downloading has completed and next to the 'Cancel' button. Also the style now matches the downloading stats text instead of the 'Cancel' button [(screenshot)](https://user-images.githubusercontent.com/38388670/100412730-1d44e900-307e-11eb-9757-061dc9d761ae.PNG)


* Removed (my) bad obsolete code for the minimize loading screen function which was never implemented because of issues. If such function is ever added it will be a lot better to be rewritten, the way the old one tried to go about it was a mess.