### PR TITLE
Move 'Cache Folder' button after the filename field

### DIFF
--- a/src/app/lib/views/player/loading.js
+++ b/src/app/lib/views/player/loading.js
@@ -63,9 +63,7 @@
       'mousedown .title': 'titletoclip',
       'mousedown .text_filename': 'filenametoclip',
       'mousedown .text_streamurl': 'streamurltoclip',
-      'click .playing-progressbar': 'seekStreaming',
-      'mouseover .text_filename': 'filenameovrflsh',
-      'mouseout .text_filename': 'filenameovrflhd'
+      'click .playing-progressbar': 'seekStreaming'
     },
 
     initialize: function() {
@@ -357,14 +355,6 @@
 
     tempf: function (e) {
       nw.Shell.openExternal(Settings.tmpLocation);
-    },
-
-    filenameovrflsh: function () {
-      $('.text_filename').css('overflow', 'visible');
-    },
-
-    filenameovrflhd: function () {
-      $('.text_filename').css('overflow', 'hidden');
     },
 
     remainingTime: function () {

--- a/src/app/styl/views/loading.styl
+++ b/src/app/styl/views/loading.styl
@@ -189,8 +189,9 @@
         .open-button
             float right
             cursor pointer
-            transition opacity .3s
-            opacity 0.3
+            transition opacity .2s
+            opacity 0.4
+            z-index 10
 
             &:hover
                 opacity 1
@@ -244,6 +245,15 @@
 
                 &:hover
                     overflow visible
+
+            .show-pcontrols
+                float right
+                cursor pointer
+                transition opacity .2s
+                opacity 0.4
+
+                &:hover
+                    opacity 1
 
             .buffer_percent
                 text-align center

--- a/src/app/styl/views/loading.styl
+++ b/src/app/styl/views/loading.styl
@@ -230,10 +230,20 @@
 
                 &.loading-info-text
                     float left
-                    padding-right 30px
+                    padding-right 32px
                 &.value
                     float right
                     text-align right
+
+            .text_filename
+                max-width 255px
+                padding-right 2px
+                overflow hidden
+                white-space nowrap
+                text-overflow ellipsis
+
+                &:hover
+                    overflow visible
 
             .buffer_percent
                 text-align center

--- a/src/app/templates/loading.tpl
+++ b/src/app/templates/loading.tpl
@@ -72,7 +72,7 @@
                     <span class="text_filename value tooltipped" data-toggle="tooltip" data-placement="bottom" title="<%= i18n.__("Right click to copy") %>"></span><br>
                     <span class="loading-info-text"><%= i18n.__("Stream Url") %>:&nbsp;</span>
                     <span class="text_streamurl value tooltipped" data-toggle="tooltip" data-placement="bottom" title="<%= i18n.__("Right click to copy") %>"></span><br>
-                    <div class="fa fa-angle-down show-pcontrols tooltipped" style="float:right;cursor:pointer;opacity:0.4;" "data-toggle="tooltip" data-placement="bottom" title="<%= i18n.__("Show playback controls") %>"></div>
+                    <div class="fa fa-angle-down show-pcontrols tooltipped" data-toggle="tooltip" data-placement="bottom" title="<%= i18n.__("Show playback controls") %>"></div>
                     <div class="player-controls" style="display:none;">
                         <i class="fa fa-backward backward"></i>
                         <i class="fa fa-pause pause"></i>

--- a/src/app/templates/loading.tpl
+++ b/src/app/templates/loading.tpl
@@ -68,11 +68,11 @@
                     <span class="loading-info-text" id="ractpr"><%= i18n.__("Active Peers") %>:&nbsp;</span>
                     <span class="value_peers value">0</span><span id="rbreak3" style="line-height:13px;"><br></span>
                     <span class="loading-info-text"><%= i18n.__("Filename") %>:&nbsp;</span>
-                    <span class="text_filename value tooltipped" style="white-space:nowrap;max-width:257px;padding-left:5px;overflow:hidden;text-overflow:ellipsis;" data-toggle="tooltip" data-placement="bottom" title="<%= i18n.__("Right click to copy") %>"></span>
-                    <span class="open-button tooltipped" data-toggle="tooltip" data-placement="bottom" title="<%= i18n.__("Cache Folder") %>"><i class="fa fa-folder-open"></i></span><br>
+                    <span class="open-button tooltipped" data-toggle="tooltip" data-placement="bottom" title="<%= i18n.__("Cache Folder") %>"><i class="fa fa-folder-open"></i></span>
+                    <span class="text_filename value tooltipped" data-toggle="tooltip" data-placement="bottom" title="<%= i18n.__("Right click to copy") %>"></span><br>
                     <span class="loading-info-text"><%= i18n.__("Stream Url") %>:&nbsp;</span>
                     <span class="text_streamurl value tooltipped" data-toggle="tooltip" data-placement="bottom" title="<%= i18n.__("Right click to copy") %>"></span><br>
-                    <div class="fa fa-angle-down show-pcontrols tooltipped" style="float:right;cursor:pointer;opacity:0.5;" "data-toggle="tooltip" data-placement="bottom" title="<%= i18n.__("Show playback controls") %>"></div>
+                    <div class="fa fa-angle-down show-pcontrols tooltipped" style="float:right;cursor:pointer;opacity:0.4;" "data-toggle="tooltip" data-placement="bottom" title="<%= i18n.__("Show playback controls") %>"></div>
                     <div class="player-controls" style="display:none;">
                         <i class="fa fa-backward backward"></i>
                         <i class="fa fa-pause pause"></i>


### PR DESCRIPTION
[before](https://user-images.githubusercontent.com/38388670/100482218-48235180-30ff-11eb-9ea9-01297147616b.png), [after](https://user-images.githubusercontent.com/38388670/100482222-4a85ab80-30ff-11eb-99ea-00fab0301dfb.png)
(I promise I'll stop moving this thing around lol)

Also moved some existing inline css from loading .js&.tpl to .styl and added hover effect to the 'Show playback controls' arrow (opacity 0.4 -> 1 in 0.2s like the 'Cache Folder' button above it)
