### PR TITLE
Fix opening cache folder behaviour

### DIFF
--- a/src/app/app.js
+++ b/src/app/app.js
@@ -389,7 +389,7 @@ Mousetrap.bindGlobal(['shift+f12', 'f12', 'command+0'], function (e) {
 });
 Mousetrap.bindGlobal(['shift+f10', 'f10', 'command+9'], function (e) {
   win.debug('Opening: ' + App.settings.tmpLocation);
-  nw.Shell.openItem(App.settings.tmpLocation);
+  App.settings.os === 'windows' ? nw.Shell.openExternal(App.settings.tmpLocation) : nw.Shell.openItem(App.settings.tmpLocation);
 });
 Mousetrap.bind('mod+,', function (e) {
   App.vent.trigger('about:close');

--- a/src/app/lib/views/browser/filter_bar.js
+++ b/src/app/lib/views/browser/filter_bar.js
@@ -358,7 +358,7 @@
     },
 
     tempf: function (e) {
-      nw.Shell.openExternal(Settings.tmpLocation);
+      App.settings.os === 'windows' ? nw.Shell.openExternal(Settings.tmpLocation) : nw.Shell.openItem(Settings.tmpLocation);
     },
 
     about: function(e) {

--- a/src/app/lib/views/player/loading.js
+++ b/src/app/lib/views/player/loading.js
@@ -354,7 +354,7 @@
     },
 
     tempf: function (e) {
-      nw.Shell.openExternal(Settings.tmpLocation);
+      App.settings.os === 'windows' ? nw.Shell.openExternal(Settings.tmpLocation) : nw.Shell.openItem(Settings.tmpLocation);
     },
 
     remainingTime: function () {

--- a/src/app/lib/views/settings_container.js
+++ b/src/app/lib/views/settings_container.js
@@ -177,7 +177,7 @@
             if (el[0].classList.contains('import-db')) {
                 $('#importdb-modal, #importdb-overlay').fadeIn(500);
             }
-        },        
+        },
 
         closeModal: function (e) {
             var el = $(e.currentTarget);
@@ -414,7 +414,7 @@
                     App.vent.trigger('torrentCollection:close');
                     $('.nav-hor.left li:first').click();
                     App.vent.trigger('settings:show');
-                    if (AdvSettings.get('startScreen') === 'Torrent-collection') { 
+                    if (AdvSettings.get('startScreen') === 'Torrent-collection') {
                         $('select[name=start_screen]').change();
                     }
                     break;
@@ -422,7 +422,7 @@
                     App.vent.trigger('favorites:list');
                     $('.nav-hor.left li:first').click();
                     App.vent.trigger('settings:show');
-                    if (AdvSettings.get('startScreen') === 'Movies') { 
+                    if (AdvSettings.get('startScreen') === 'Movies') {
                         $('select[name=start_screen]').change();
                     }
                     break;
@@ -430,7 +430,7 @@
                     App.vent.trigger('favorites:list');
                     $('.nav-hor.left li:first').click();
                     App.vent.trigger('settings:show');
-                    if (AdvSettings.get('startScreen') === 'TV Series') { 
+                    if (AdvSettings.get('startScreen') === 'TV Series') {
                         $('select[name=start_screen]').change();
                     }
                     break;
@@ -438,14 +438,14 @@
                     App.vent.trigger('favorites:list');
                     $('.nav-hor.left li:first').click();
                     App.vent.trigger('settings:show');
-                    if (AdvSettings.get('startScreen') === 'Anime') { 
+                    if (AdvSettings.get('startScreen') === 'Anime') {
                         $('select[name=start_screen]').change();
                     }
                     break;
                 case 'activateWatchlist':
                     $('.nav-hor.left li:first').click();
                     App.vent.trigger('settings:show');
-                    if (AdvSettings.get('startScreen') === 'Watchlist') { 
+                    if (AdvSettings.get('startScreen') === 'Watchlist') {
                         $('select[name=start_screen]').change();
                     }
                     break;
@@ -453,7 +453,7 @@
                     App.vent.trigger('seedbox:close');
                     $('.nav-hor.left li:first').click();
                     App.vent.trigger('settings:show');
-                    if (AdvSettings.get('startScreen') === 'Seedbox') { 
+                    if (AdvSettings.get('startScreen') === 'Seedbox') {
                         $('select[name=start_screen]').change();
                     }
                     break;
@@ -655,7 +655,7 @@
 
         openTmpFolder: function () {
             win.debug('Opening: ' + App.settings['tmpLocation']);
-            nw.Shell.openItem(App.settings['tmpLocation']);
+            App.settings.os === 'windows' ? nw.Shell.openExternal(App.settings['tmpLocation']) : nw.Shell.openItem(App.settings['tmpLocation']);
         },
 
         moveTmpLocation: function (location) {
@@ -667,13 +667,13 @@
                 deleteFolder(oldTmpLocation);
             } else {
                 $('.notification_alert').show().text(i18n.__('You should save the content of the old directory, then delete it')).delay(5000).fadeOut(400);
-                nw.Shell.openItem(oldTmpLocation);
+                App.settings.os === 'windows' ? nw.Shell.openExternal(oldTmpLocation) : nw.Shell.openItem(oldTmpLocation);
             }
         },
 
         openDatabaseFolder: function () {
             win.debug('Opening: ' + App.settings['databaseLocation']);
-            nw.Shell.openItem(App.settings['databaseLocation']);
+            App.settings.os === 'windows' ? nw.Shell.openExternal(App.settings['databaseLocation']) : nw.Shell.openItem(App.settings['databaseLocation']);
         },
 
         exportDatabase: function (e) {

--- a/src/app/lib/views/torrent_collection.js
+++ b/src/app/lib/views/torrent_collection.js
@@ -561,7 +561,7 @@
 
         openCollection: function () {
             console.debug('Opening: ' + collection);
-            nw.Shell.openItem(collection);
+            App.settings.os === 'windows' ? nw.Shell.openExternal(collection) : nw.Shell.openItem(collection);
         },
 
         notorrentsClick: function (e) {


### PR DESCRIPTION
So it seem nw.Shell.openItem is usual way to open a folder in file
explorer but on Windows it open an explorer window with side panel
folders tree expended (exploring mode), instead of side panel
folders tree unexpended (opening mode - default OS behaviour).

So, using nw.Shell.openExternal to open a local folder on windows
open an explorer window in opening mode, but then it doesn't
works on linux.

So we mix both and add condition depending the os, so we obtain the
desired result.