### PR TITLE
Add 'T' as additional 'Cache Folder' shortcut

### DIFF
--- a/src/app/app.js
+++ b/src/app/app.js
@@ -387,8 +387,7 @@ Mousetrap.bindGlobal(['alt+f4', 'command+q'], function (e) {
 Mousetrap.bindGlobal(['shift+f12', 'f12', 'command+0'], function (e) {
   win.showDevTools();
 });
-Mousetrap.bindGlobal(['shift+f10', 'f10', 'command+9'], function (e) {
-  win.debug('Opening: ' + App.settings.tmpLocation);
+Mousetrap.bindGlobal(['shift+f10', 'f10', 'command+9', 't'], function (e) {
   nw.Shell.openItem(App.settings.tmpLocation);
 });
 Mousetrap.bind('mod+,', function (e) {

--- a/src/app/templates/keyboard.tpl
+++ b/src/app/templates/keyboard.tpl
@@ -25,7 +25,7 @@
                         <td><%= i18n.__("Open Favorites") %></td>
                     </tr>
                     <tr>
-                        <td><span class="key delete">F10</span></td>
+                        <td><span class="key delete">F10</span>/<span class="key">T</span></td>
                         <td><%= i18n.__("Open Cache Folder") %></td>
                     </tr>
                     <tr>


### PR DESCRIPTION
The rest of the tabs and filterbar buttons dont use F keys and also F10 is a little precariously placed next to F11 which restarts Popcorn Time.

![2](https://user-images.githubusercontent.com/38388670/100519945-d4875000-31a3-11eb-8868-66e901407a2b.jpg)
