### PR TITLE
Fix show detail 'Mark as Seen' switching page/season

### DIFF
--- a/src/app/lib/views/show_detail.js
+++ b/src/app/lib/views/show_detail.js
@@ -393,8 +393,7 @@
 
         onWatched: function (value, channel) {
             this.markWatched(value, true);
-
-            this.selectNextEpisode();
+            this.nextEpisode();
         },
 
         onUnWatched: function (value, channel) {


### PR DESCRIPTION
*fixes https://github.com/popcorn-official/popcorn-desktop/issues/897

`selectNextEpisode()` jumps to the first not watched episode after the last marked as watched episode, which many times might be on a different season (e.g the last marked as watched episode you have is S10E04, and you are currently marking S04E01, S04E02 etc as watched, everyone you mark the view and selection jumps to S10E05 causing you to need to go back where you were everytime)

`nextEpisode()` just selects the next episode on the list, if you are on the last episode of a specific season it will stay on that