### PR TITLE
Fix resetting torrent health in movie/episode detail

### DIFF
--- a/src/app/lib/views/movie_detail.js
+++ b/src/app/lib/views/movie_detail.js
@@ -30,7 +30,8 @@
       'click .showall-cast': 'showallCast',
       'click .q2160': 'toggleShowQuality',
       'click .q1080': 'toggleShowQuality',
-      'click .q720': 'toggleShowQuality'
+      'click .q720': 'toggleShowQuality',
+      'click .health-icon': 'resetTorrentHealth'
     },
 
     regions: {
@@ -342,6 +343,12 @@
     retrieveTorrentHealth: function(cb) {
       const torrent = this.model.get('torrents')[this.model.get('quality')];
       Common.retrieveTorrentHealth(torrent, cb);
+    },
+
+    resetTorrentHealth: function () {
+      $('.health-icon').tooltip('hide');
+      healthButton.reset();
+      healthButton.render();
     },
 
     openIMDb: function() {

--- a/src/app/lib/views/show_detail.js
+++ b/src/app/lib/views/show_detail.js
@@ -727,6 +727,7 @@
         },
 
         resetTorrentHealth: function () {
+            $('.health-icon').tooltip('hide');
             healthButton.reset();
             healthButton.render();
         },


### PR DESCRIPTION
The one in movie detail wasn't doing anything when clicked. The whole function must've gotten accidentally removed at some point (or if it wasn't accidentally I cant find a reason why). Also both of them in movie and episode detail didn't hide the tooltip when clicked so it remained with the old stats until the user moved his cursor off the health indicator.