### PR TITLE
Prevent show detail from resetting mousetrap

### DIFF
--- a/src/app/lib/views/show_detail.js
+++ b/src/app/lib/views/show_detail.js
@@ -97,6 +97,7 @@
             this.model.set('torrents', torrents);
             this.model.set('seasonCount', Object.keys(torrents).length);
         },
+
         renameUntitled: function () {
             var episodes = this.model.get('episodes');
             for (var i = 0; i < episodes.length; i++) {
@@ -111,6 +112,7 @@
                 }
             }
         },
+
         initKeyboardShortcuts: function () {
             Mousetrap.bind('q', _this.toggleQuality);
             Mousetrap.bind('down', _this.nextEpisode);
@@ -125,7 +127,17 @@
             });
         },
 
-        unbindKeyboardShortcuts: Mousetrap.reset,
+        unbindKeyboardShortcuts: function () {
+            Mousetrap.unbind('q');
+            Mousetrap.unbind('down');
+            Mousetrap.unbind('up');
+            Mousetrap.unbind('w');
+            Mousetrap.unbind(['enter', 'space']);
+            Mousetrap.unbind(['esc', 'backspace']);
+            Mousetrap.unbind(['ctrl+up', 'command+up']);
+            Mousetrap.unbind(['ctrl+down', 'command+down']);
+            Mousetrap.unbind('f');
+        },
 
         onAttach: function () {
             bookmarked = App.userBookmarks.indexOf(this.model.get('imdb_id')) !== -1;


### PR DESCRIPTION
This `Mousetrap.reset` wreaks all sorts of havoc to the keyboard shortcuts after you exit show detail and even though most parent views these days try and rebind their shortcuts some don't (e.g list.js does, app.js doesn't)

Changed show_detail.js to just unbinding whatever it binds on exit like all other views do so it doesn't cause this issue.