### PR TITLE
'Sort by' filter fixes

### DIFF
--- a/src/app/lib/views/browser/filter_bar.js
+++ b/src/app/lib/views/browser/filter_bar.js
@@ -223,6 +223,10 @@
           this.fixFilter();
         } catch (e) {}
       }
+
+      if (!this.previousSort) {
+        this.previousSort = $('.sorters .active').data('value') || $('.sorters .value').data('value');
+      }
     },
 
     focusSearch: function() {
@@ -305,19 +309,26 @@
       var sorter = $(e.target).attr('data-value');
 
       if (this.previousSort === sorter) {
-        this.model.set('order', this.model.get('order') * -1);
+        this.model.set({
+          order: this.model.get('order') * -1,
+          keyword: '',
+          sorter: sorter
+        });
       } else if (this.previousSort !== sorter && sorter === 'title') {
-        this.model.set('order', this.model.get('order') * -1);
+        this.model.set({
+          order: 1,
+          keyword: '',
+          sorter: sorter
+        });
       } else {
-        this.model.set('order', -1);
+        this.model.set({
+          order: -1,
+          keyword: '',
+          sorter: sorter
+        });
       }
 
       this.ui.sorterValue.text(i18n.__(sorter.capitalizeEach()));
-
-      this.model.set({
-        keyword: '',
-        sorter: sorter
-      });
       this.previousSort = sorter;
     },
 


### PR DESCRIPTION
Fixes the following issues:

- When you first start the app, switch tabs, switch genre, search for something, or basically anything that refreshes the list view, the default 'Sort by' filter needs to be clicked twice to change the order to ascending (*only if you have 'remember filters' disabled which is also the default option)

- When switching from another 'Sort by' filter 'Title' needs to be clicked twice to load, and three times to display the correct default descending order (*'Title' is also different from other filters as it starts with ascending order, A to Z instead of 2020 to 0 for e.g 'Year' or any of the others)

- When you switch from any 'Sort by' filter sorted as ascending (=not default order) and you select any different filter, it needs to be clicked twice to load and three times to display the correct default descending order

&nbsp;

*also fixes https://github.com/popcorn-official/popcorn-desktop/issues/1905

@Persei08 (and everyone else who wants to do so) everything looks ok so merging but when you can can you also please test this in case I've missed something? thanks!