### PR TITLE
Add tab selection for 'Custom API Server'

### DIFF
--- a/src/app/butter-provider/anime.js
+++ b/src/app/butter-provider/anime.js
@@ -93,22 +93,6 @@ function formatDetail(anime) {
   return sanitize(result);
 }
 
-function processCloudFlareHack(options, url) {
-  var req = options;
-  var match = url.match(/^cloudflare\+(.*):\/\/(.*)/);
-  if (match) {
-    req = _.extend(req, {
-      uri: match[1] + '://cloudflare.com/',
-      headers: {
-        Host: match[2],
-        'User-Agent':
-          'Mozilla/5.0 (Linux) AppleWebkit/534.30 (KHTML, like Gecko) PT/3.8.0'
-      }
-    });
-  }
-  return req;
-}
-
 function get(index, url, that) {
   var deferred = Q.defer();
 
@@ -117,7 +101,7 @@ function get(index, url, that) {
     json: true
   };
 
-  var req = processCloudFlareHack(options, that.apiURL[index]);
+  var req = that.buildRequest(options, that.apiURL[index]);
   console.info('Request to AnimeApi', req.url);
   request(req, function(err, res, data) {
     if (err || res.statusCode >= 400) {

--- a/src/app/language/en.json
+++ b/src/app/language/en.json
@@ -546,5 +546,6 @@
 	"No shows found...": "No shows found...",
 	"No anime found...": "No anime found...",
 	"Search in %s": "Search in %s",
-	"Show 'Search on Torrent Collection' in search": "Show 'Search on Torrent Collection' in search"
+	"Show 'Search on Torrent Collection' in search": "Show 'Search on Torrent Collection' in search",
+	"for": "for"
 }

--- a/src/app/lib/providers/generic.js
+++ b/src/app/lib/providers/generic.js
@@ -9,8 +9,11 @@
   function updateProviderConnection (server, proxy) {
     for (let provider in cache) {
       if (cache[provider] && cache[provider].apiURL) {
-        cache[provider].apiURL = [server];
         cache[provider].proxy = proxy;
+        if ((cache[provider].name.includes('Movie') && !Settings.customApiMovies) || (cache[provider].name.includes('TV') && !Settings.customApiSeries) || (cache[provider].name.includes('Anime') && !Settings.customApiAnime)) {
+          return;
+        }
+        cache[provider].apiURL = [server];
       }
     }
   }

--- a/src/app/lib/views/settings_container.js
+++ b/src/app/lib/views/settings_container.js
@@ -285,6 +285,9 @@
                 case 'moviesTabEnable':
                 case 'seriesTabEnable':
                 case 'animeTabEnable':
+                case 'customApiMovies':
+                case 'customApiSeries':
+                case 'customApiAnime':
                     value = field.is(':checked');
                     break;
                 case 'httpApiEnabled':
@@ -478,6 +481,9 @@
                     this.alertMessageSuccess(true);
                     break;
                 case 'apiServer':
+                case 'customApiMovies':
+                case 'customApiSeries':
+                case 'customApiAnime':
                     this.alertMessageSuccess(true);
                     break;
                 case 'translateSynopsis':

--- a/src/app/settings.js
+++ b/src/app/settings.js
@@ -114,6 +114,9 @@ Settings.trackers = {
 // API Servers
 Settings.apiServer = '';
 Settings.proxyServer = '';
+Settings.customApiMovies = true;
+Settings.customApiSeries = true;
+Settings.customApiAnime = true;
 
 // User interface
 Settings.language = '';

--- a/src/app/templates/settings-container.tpl
+++ b/src/app/templates/settings-container.tpl
@@ -504,10 +504,21 @@
             <span>
                 <div class="opensubtitles-options">
                     <p><%= i18n.__("Custom API Server") %></p>
-                    <input type="text" size="100" id="apiServer" name="apiServer" value="<%= Settings.apiServer %>" placeholder="http(s)://server.com/ (support .onion and .i2p urls)">
+                    <input type="text" size="50" id="apiServer" name="apiServer" value="<%= Settings.apiServer %>" placeholder="http(s)://server.com/ (support .onion and .i2p urls)">
                     <div class="loading-spinner" style="display: none"></div>
                     <div class="valid-tick" style="display: none"></div>
                     <div class="invalid-cross" style="display: none"></div>
+                    <div style="display:inline-block;<%=(Settings.apiServer === ''? 'opacity:0.4"':'"')%>>
+                        &nbsp;&nbsp;&nbsp;&nbsp;<em><%= i18n.__("for") %></em>&nbsp;&nbsp;&nbsp;&nbsp;
+                        <input class="settings-checkbox" name="customApiMovies" id="customApiMovies" type="checkbox" <%=(Settings.customApiMovies? "checked='checked'":"")%> <%=(Settings.apiServer === ''? "disabled='disabled'":"")%>>
+                        <label class="settings-label" for="customApiMovies"><em><%= i18n.__("Movies") %></em></label>
+                        &nbsp;&nbsp;&nbsp;&nbsp;
+                        <input class="settings-checkbox" name="customApiSeries" id="customApiSeries" type="checkbox" <%=(Settings.customApiSeries? "checked='checked'":"")%> <%=(Settings.apiServer === ''? "disabled='disabled'":"")%>>
+                        <label class="settings-label" for="customApiSeries"><em><%= i18n.__("Series") %></em></label>
+                        &nbsp;&nbsp;&nbsp;&nbsp;
+                        <input class="settings-checkbox" name="customApiAnime" id="customApiAnime" type="checkbox" <%=(Settings.customApiAnime? "checked='checked'":"")%> <%=(Settings.apiServer === ''? "disabled='disabled'":"")%>>
+                        <label class="settings-label" for="customApiAnime"><em><%= i18n.__("Anime") %></em></label>
+                    </div>
                 </div>
             </span>
             <span>


### PR DESCRIPTION
Lets you select which tab(s) the 'Custom API Server' option applies to (default is all)

&nbsp;

Edit: Small fix with https://github.com/popcorn-official/popcorn-desktop/commit/18cc572f3c6594973d4b2aba629f37bc4b29fb3b