### PR TITLE
Improve torrent health check

### DIFF
--- a/src/app/common.js
+++ b/src/app/common.js
@@ -61,7 +61,7 @@ Common.retrieveTorrentHealth = function (torrent, cb) {
 	torrentHealth(
 		torrentURL,
 		{
-			timeout: 1000,
+			timeout: 2000,
 			trackers: Settings.trackers.forced
 		},
 		cb
@@ -73,7 +73,7 @@ Common.HealthButton = function (selector, retrieveHealthCallback) {
 		throw new TypeError('This class must be constructed with "new"');
 	}
 
-	const maxChecksWhenNoSeeds = 5;
+	const maxChecksWhenNoSeeds = 4;
 	let zeroSeedCheckCount = 0;
 	let pendingRender = null;
 

--- a/src/app/lib/views/movie_detail.js
+++ b/src/app/lib/views/movie_detail.js
@@ -352,7 +352,7 @@
         if ($('.health-icon ~ .tooltip').is(':visible')) {
           $('.health-icon').tooltip('fixTitle').tooltip('show');
         }
-      }, 1100);
+      }, 2100);
     },
 
     openIMDb: function() {

--- a/src/app/lib/views/show_detail.js
+++ b/src/app/lib/views/show_detail.js
@@ -750,7 +750,7 @@
                 if ($('.health-icon ~ .tooltip').is(':visible')) {
                     $('.health-icon').tooltip('fixTitle').tooltip('show');
                 }
-            }, 1100);
+            }, 2100);
         },
 
         selectPlayer: function (e) {


### PR DESCRIPTION
Changed from 1 + 5 retries x 1 sec each (6 sec total) to 1 + 4 retries x 2 sec each (10 sec total)

Normal torrents and connections should only need the first try so 1 sec -> 2 sec which gives it a little more time for more trackers to return data which makes the average a bit more accurate.

Bad torrents and/or bad connections that do multiple retries to return something would go from 6 sec max to 10 sec max but with 2 sec each retry to hopefully return something and maybe even need less retries total because of it.