### PR TITLE
Add some small poster image features

### DIFF
--- a/src/app/lib/views/movie_detail.js
+++ b/src/app/lib/views/movie_detail.js
@@ -31,7 +31,8 @@
       'click .q2160': 'toggleShowQuality',
       'click .q1080': 'toggleShowQuality',
       'click .q720': 'toggleShowQuality',
-      'click .health-icon': 'resetTorrentHealth'
+      'click .health-icon': 'resetTorrentHealth',
+      'mousedown .mcover-image': 'clickPoster'
     },
 
     regions: {
@@ -293,6 +294,14 @@
     showallCast: function () {
       $('.overview').html(curSynopsis.crew + curSynopsis.allcast + curSynopsis.old);
       $('.overview *').tooltip({html: true, sanitize: false, container: 'body', placement: 'bottom', delay: {show: 200, hide: 0}, template: '<div class="tooltip" style="opacity:1"><div class="tooltip-inner" style="background-color:rgba(0,0,0,0);width:118px"></div></div>'});
+    },
+
+    clickPoster: function(e) {
+      if (e.button === 2) {
+        var clipboard = nw.Clipboard.get();
+        clipboard.set($('.mcover-image')[0].src, 'text');
+        $('.notification_alert').text(i18n.__('The image url was copied to the clipboard')).fadeIn('fast').delay(2500).fadeOut('fast');
+      }
     },
 
     onBeforeDestroy: function() {

--- a/src/app/lib/views/show_detail.js
+++ b/src/app/lib/views/show_detail.js
@@ -31,7 +31,8 @@
             'dblclick .tab-episode': 'dblclickEpisode',
             'click .playerchoicemenu li a': 'selectPlayer',
             'click .shmi-rating': 'switchRating',
-            'click .health-icon': 'refreshTorrentHealth'
+            'click .health-icon': 'refreshTorrentHealth',
+            'mousedown .sh-poster': 'clickPoster'
         },
 
         regions: {
@@ -731,6 +732,16 @@
             return (
                 (eap = efp(rect.left, rect.top)) === el || el[contains](eap) === has || (eap = efp(rect.right, rect.top)) === el || el[contains](eap) === has || (eap = efp(rect.right, rect.bottom)) === el || el[contains](eap) === has || (eap = efp(rect.left, rect.bottom)) === el || el[contains](eap) === has
             );
+        },
+
+        clickPoster: function(e) {
+            if (e.button === 0) {
+                $('.sh-poster').toggleClass('active');
+            } else if (e.button === 2) {
+                var clipboard = nw.Clipboard.get();
+                clipboard.set($('.shp-img')[0].style.backgroundImage.slice(4, -1).replace(/"/g, ""), 'text');
+                $('.notification_alert').text(i18n.__('The image url was copied to the clipboard')).fadeIn('fast').delay(2500).fadeOut('fast');
+            }
         },
 
         retrieveTorrentHealth: function(cb) {

--- a/src/app/styl/views/show_detail.styl
+++ b/src/app/styl/views/show_detail.styl
@@ -30,6 +30,7 @@
             float: left
             width: 198px
             height: 100%
+            cursor: pointer
 
             .shp-img
                 position relative
@@ -47,6 +48,14 @@
                 &.fadein
                     transition: opacity .3s ease-in;
                     opacity: 1
+
+        .sh-poster.active
+            zoom: 350%
+            position: absolute
+            z-index: 20
+
+            + .sh-metadata, ~ .sh-actions
+                left: 198px
 
         .sh-metadata
             float: left


### PR DESCRIPTION
- Clicking the poster image in episode detail will zoom it by 350% (then back to 100% once you click again)

- Right clicking the poster image in either movie or episode detail will copy the image url to the clipboard.