### PR TITLE
Add supported external players popup

### DIFF
--- a/src/app/language/en.json
+++ b/src/app/language/en.json
@@ -550,5 +550,8 @@
 	"Custom Movies Server": "Custom Movies Server",
 	"Custom Series Server": "Custom Series Server",
 	"Custom Anime Server": "Custom Anime Server",
-	"The image url was copied to the clipboard": "The image url was copied to the clipboard"
+	"The image url was copied to the clipboard": "The image url was copied to the clipboard",
+	"Popcorn Time currently supports": "Popcorn Time currently supports",
+	"There is also support for Chromecast, AirPlay & DLNA devices.": "There is also support for Chromecast, AirPlay & DLNA devices.",
+	"Right click for supported players": "Right click for supported players"
 }

--- a/src/app/lib/views/file_selector.js
+++ b/src/app/lib/views/file_selector.js
@@ -51,7 +51,7 @@
             if (!$.trim($('.file-selector-container .file-list').html()).length) {
                 $('.file-selector-container .file-list').html('<li style="margin-top: 30px">' + i18n.__('No results found') + '</li>');
             }
-            $('.playerchoice').tooltip({html: true, delay: {show: 800, hide: 100}});
+            $('.playerchoice').tooltip({html: true, delay: {show: 1800, hide: 100}});
         },
 
         bitsnoopRequest: function (hash) {

--- a/src/app/lib/views/file_selector.js
+++ b/src/app/lib/views/file_selector.js
@@ -12,7 +12,8 @@
             'click .close-icon': 'closeSelector',
             'click .file-item': 'startStreaming',
             'click .store-torrent': 'storeTorrent',
-            'click .playerchoicemenu li a': 'selectPlayer'
+            'click .playerchoicemenu li a': 'selectPlayer',
+            'mousedown .playerchoice': 'showPlayerList'
         },
 
         initialize: function () {
@@ -50,6 +51,7 @@
             if (!$.trim($('.file-selector-container .file-list').html()).length) {
                 $('.file-selector-container .file-list').html('<li style="margin-top: 30px">' + i18n.__('No results found') + '</li>');
             }
+            $('.playerchoice').tooltip({html: true, delay: {show: 800, hide: 100}});
         },
 
         bitsnoopRequest: function (hash) {
@@ -168,6 +170,16 @@
             that.model.set('device', player);
             if (!player.match(/[0-9]+.[0-9]+.[0-9]+.[0-9]/ig)) {
                 AdvSettings.set('chosenPlayer', player);
+            }
+        },
+
+        showPlayerList: function(e) {
+            if (e.button === 2) {
+                App.vent.trigger('notification:show', new App.Model.Notification({
+                    title: '',
+                    body: i18n.__('Popcorn Time currently supports') + '<br>VLC, Fleex player, MPlayer, MPlayerX, MPlayer OSX Ext., IINA, mpv, mpv.net, MPC-HC, MPC-BE, SMPlayer, Bomi & BSPlayer.<br><br>' + i18n.__('There is also support for Chromecast, AirPlay & DLNA devices.'),e,
+                    type: 'success'
+                }));
             }
         },
 

--- a/src/app/lib/views/play_control.js
+++ b/src/app/lib/views/play_control.js
@@ -14,6 +14,7 @@
       'click #download-torrent': 'downloadTorrent',
       'click .favourites-toggle': 'toggleFavourite',
       'click .playerchoicemenu li a': 'selectPlayer',
+      'mousedown .playerchoice': 'showPlayerList',
       'click .watched-toggle': 'toggleWatched'
     },
     regions: {
@@ -127,6 +128,8 @@
       $('.star-container,.movie-imdb-link,.q720,input,.magnet-link,.show-cast').tooltip({
         html: true
       });
+
+      $('.playerchoice').tooltip({html: true, delay: {show: 800, hide: 100}});
 
       // Bookmarked / not bookmarked
       if (this.model.get('bookmarked')) {
@@ -302,6 +305,16 @@
       this.model.set('device', player);
       if (!player.match(/[0-9]+.[0-9]+.[0-9]+.[0-9]/gi)) {
         AdvSettings.set('chosenPlayer', player);
+      }
+    },
+
+    showPlayerList: function(e) {
+      if (e.button === 2) {
+        App.vent.trigger('notification:show', new App.Model.Notification({
+          title: '',
+          body: i18n.__('Popcorn Time currently supports') + '<br>VLC, Fleex player, MPlayer, MPlayerX, MPlayer OSX Ext., IINA, mpv, mpv.net, MPC-HC, MPC-BE, SMPlayer, Bomi & BSPlayer.<br><br>' + i18n.__('There is also support for Chromecast, AirPlay & DLNA devices.'),
+          type: 'success'
+        }));
       }
     },
 

--- a/src/app/lib/views/play_control.js
+++ b/src/app/lib/views/play_control.js
@@ -129,7 +129,7 @@
         html: true
       });
 
-      $('.playerchoice').tooltip({html: true, delay: {show: 800, hide: 100}});
+      $('.playerchoice').tooltip({html: true, delay: {show: 1800, hide: 100}});
 
       // Bookmarked / not bookmarked
       if (this.model.get('bookmarked')) {

--- a/src/app/lib/views/show_detail.js
+++ b/src/app/lib/views/show_detail.js
@@ -32,7 +32,8 @@
             'click .playerchoicemenu li a': 'selectPlayer',
             'click .shmi-rating': 'switchRating',
             'click .health-icon': 'refreshTorrentHealth',
-            'mousedown .sh-poster': 'clickPoster'
+            'mousedown .sh-poster': 'clickPoster',
+            'mousedown .playerchoice': 'showPlayerList'
         },
 
         regions: {
@@ -222,6 +223,7 @@
             App.Device.Collection.setDevice(Settings.chosenPlayer);
             App.Device.ChooserView('#player-chooser').render();
             $('.spinner').hide();
+            $('.playerchoice').tooltip({html: true, delay: {show: 800, hide: 100}});
         },
 
         selectNextEpisode: function () {
@@ -769,6 +771,16 @@
             _this.model.set('device', player);
             if (!player.match(/[0-9]+.[0-9]+.[0-9]+.[0-9]/ig)) {
                 AdvSettings.set('chosenPlayer', player);
+            }
+        },
+
+        showPlayerList: function(e) {
+            if (e.button === 2) {
+                App.vent.trigger('notification:show', new App.Model.Notification({
+                    title: '',
+                    body: i18n.__('Popcorn Time currently supports') + '<br>VLC, Fleex player, MPlayer, MPlayerX, MPlayer OSX Ext., IINA, mpv, mpv.net, MPC-HC, MPC-BE, SMPlayer, Bomi & BSPlayer.<br><br>' + i18n.__('There is also support for Chromecast, AirPlay & DLNA devices.'),
+                    type: 'success'
+                }));
             }
         },
 

--- a/src/app/lib/views/show_detail.js
+++ b/src/app/lib/views/show_detail.js
@@ -223,7 +223,7 @@
             App.Device.Collection.setDevice(Settings.chosenPlayer);
             App.Device.ChooserView('#player-chooser').render();
             $('.spinner').hide();
-            $('.playerchoice').tooltip({html: true, delay: {show: 800, hide: 100}});
+            $('.playerchoice').tooltip({html: true, delay: {show: 1800, hide: 100}});
         },
 
         selectNextEpisode: function () {

--- a/src/app/templates/player-chooser.tpl
+++ b/src/app/templates/player-chooser.tpl
@@ -1,6 +1,6 @@
 <div class="button dropup" >
     <div id="watch-now" class="left startStreaming" data-torrent="" data-episodeid="" data-episode="" data-season=""><%=i18n.__("Watch Now") %></div>
-    <div class="dropdown-toggle left playerchoice tooltipped" data-toggle="dropdown" data-placement="bottom" title='<%=i18n.__("Right click for supported players") %>'>
+    <div class="dropdown-toggle left playerchoice tooltipped" data-toggle="dropdown" data-placement="bottom" title="<%=i18n.__("Right click for supported players") %>">
         <img class="imgplayerchoice" src="images/icons/local-icon.png"/>
         <span class="caret"></span>
     </div>

--- a/src/app/templates/player-chooser.tpl
+++ b/src/app/templates/player-chooser.tpl
@@ -1,6 +1,6 @@
 <div class="button dropup" >
     <div id="watch-now" class="left startStreaming" data-torrent="" data-episodeid="" data-episode="" data-season=""><%=i18n.__("Watch Now") %></div>
-    <div class="dropdown-toggle left playerchoice" data-toggle="dropdown">
+    <div class="dropdown-toggle left playerchoice tooltipped" data-toggle="dropdown" data-placement="bottom" title='<%=i18n.__("Right click for supported players") %>'>
         <img class="imgplayerchoice" src="images/icons/local-icon.png"/>
         <span class="caret"></span>
     </div>


### PR DESCRIPTION
Adds a `?` button in the player dropdown menu which when clicked displays a popup with the currently supported external players.

(*edited with #1926 & #1927, they also revert #1924 & #1925, screenshots below are updated)

![0](https://user-images.githubusercontent.com/38388670/102910354-18a80080-4483-11eb-8b76-19726851fc4f.jpg)
![1](https://user-images.githubusercontent.com/38388670/102743727-b820a280-4360-11eb-9547-da806e7f8c5c.jpg)