### PR TITLE
Dynamically get supported external player list

### DIFF
--- a/src/app/global.js
+++ b/src/app/global.js
@@ -43,3 +43,5 @@ var _ = require('underscore'),
   child = require('child_process'),
   // package.json
   pkJson = nw.App.manifest;
+  // supported external players list
+  extPlayerlst = '';

--- a/src/app/lib/device/ext-player.js
+++ b/src/app/lib/device/ext-player.js
@@ -20,6 +20,13 @@
             cmd: '/Contents/MacOS/Fleex player',
             filenameswitch: '-file-name '
         },
+        'mplayer': {
+            type: 'mplayer',
+            cmd: 'mplayer',
+            switches: '--really-quiet',
+            subswitch: '-sub ',
+            fs: '-fs',
+        },
         'MPlayerX': {
             type: 'mplayer',
             cmd: '/Contents/MacOS/MPlayerX',
@@ -41,12 +48,11 @@
             subswitch: '--mpv-sub-file=',
             fs: '--mpv-fs',
         },
-        'mplayer': {
-            type: 'mplayer',
-            cmd: 'mplayer',
-            switches: '--really-quiet',
-            subswitch: '-sub ',
-            fs: '-fs',
+        'Bomi': {
+            type: 'bomi',
+            switches: '',
+            subswitch: '--set-subtitle ',
+            fs: '--action window/enter-fs'
         },
         'mpv': {
             type: 'mpv',
@@ -93,12 +99,6 @@
             stop: 'smplayer -send-action quit',
             pause: 'smplayer -send-action pause'
         },
-        'Bomi': {
-            type: 'bomi',
-            switches: '',
-            subswitch: '--set-subtitle ',
-            fs: '--action window/enter-fs'
-        },
         'BSPlayer': {
             type: 'bsplayer',
             switches: '',
@@ -111,6 +111,8 @@
             subswitch: '/sub='
         }
     };
+
+    extPlayerlst = Object.getOwnPropertyNames(players).toString().replace(/,/g, ', ').replace("Extended", "Ext.").replace("MPC-HC64, ", "").replace("MPC-BE64, ", "").replace("PotPlayerMini64", "PotPlayer").replace("mpvnet", "mpv.net").replace("mplayer", "MPlayer").replace(/,([^,]*)$/, ' & $1');
 
     function getPlayerName(loc) {
         return path.basename(loc).replace(path.extname(loc), '');

--- a/src/app/lib/views/file_selector.js
+++ b/src/app/lib/views/file_selector.js
@@ -175,7 +175,7 @@
         showPlayerList: function(e) {
             App.vent.trigger('notification:show', new App.Model.Notification({
                 title: '',
-                body: i18n.__('Popcorn Time currently supports') + '<span class="smline"></span>' + 'VLC, Fleex player, MPlayer, MPlayerX, MPlayer OSX Ext., IINA, Bomi,<br>mpv, mpv.net, MPC-HC, MPC-BE, SMPlayer, PotPlayer & BSPlayer' + '.<span class="mmline"></span>' + i18n.__('There is also support for Chromecast, AirPlay & DLNA devices.'),
+                body: i18n.__('Popcorn Time currently supports') + '<div class="splayerlist">' + extPlayerlst + '.</div><br>' + i18n.__('There is also support for Chromecast, AirPlay & DLNA devices.'),
                 type: 'success'
             }));
         },

--- a/src/app/lib/views/play_control.js
+++ b/src/app/lib/views/play_control.js
@@ -309,7 +309,7 @@
     showPlayerList: function(e) {
       App.vent.trigger('notification:show', new App.Model.Notification({
         title: '',
-        body: i18n.__('Popcorn Time currently supports') + '<span class="smline"></span>' + 'VLC, Fleex player, MPlayer, MPlayerX, MPlayer OSX Ext., IINA, Bomi,<br>mpv, mpv.net, MPC-HC, MPC-BE, SMPlayer, PotPlayer & BSPlayer' + '.<span class="mmline"></span>' + i18n.__('There is also support for Chromecast, AirPlay & DLNA devices.'),
+        body: i18n.__('Popcorn Time currently supports') + '<div class="splayerlist">' + extPlayerlst + '.</div><br>' + i18n.__('There is also support for Chromecast, AirPlay & DLNA devices.'),
         type: 'success'
       }));
     },

--- a/src/app/lib/views/show_detail.js
+++ b/src/app/lib/views/show_detail.js
@@ -776,7 +776,7 @@
         showPlayerList: function(e) {
             App.vent.trigger('notification:show', new App.Model.Notification({
                 title: '',
-                body: i18n.__('Popcorn Time currently supports') + '<span class="smline"></span>' + 'VLC, Fleex player, MPlayer, MPlayerX, MPlayer OSX Ext., IINA, Bomi,<br>mpv, mpv.net, MPC-HC, MPC-BE, SMPlayer, PotPlayer & BSPlayer' + '.<span class="mmline"></span>' + i18n.__('There is also support for Chromecast, AirPlay & DLNA devices.'),
+                body: i18n.__('Popcorn Time currently supports') + '<div class="splayerlist">' + extPlayerlst + '.</div><br>' + i18n.__('There is also support for Chromecast, AirPlay & DLNA devices.'),
                 type: 'success'
             }));
         },

--- a/src/app/styl/views/bootstrap-theme.styl
+++ b/src/app/styl/views/bootstrap-theme.styl
@@ -80,10 +80,8 @@ ul.nav-hor > li
     &:hover
         opacity 0.97
 
-.smline
-    display block
-    height 4px
-
-.mmline
-    display block
-    height 16px
+.splayerlist
+    display inline-block
+    width 420px
+    line-height 20px
+    padding 4px 0px 14px


### PR DESCRIPTION
Gets the list from ext-player.js with a few `replace()` to format the string.
If anyone knows a better way to do this than adding it in global.js let me know, or just make a PR.

(*edited with https://github.com/popcorn-official/popcorn-desktop/commit/d5f139dd97ca7a65e664470d490e314cf590968e & https://github.com/popcorn-official/popcorn-desktop/commit/d2cd304403085d604ea24f1200eca597ef405855)