### PR TITLE
Add quality as search term for YTS

### DIFF
--- a/src/app/butter-provider/yts.js
+++ b/src/app/butter-provider/yts.js
@@ -107,6 +107,10 @@ class YTSApi extends Generic {
     }
     if (filters.keywords) {
       params.query_term = filters.keywords.replace(/\s|'|:\./g, 'temp0123').replace(/[^a-zA-Z0-9]/g,'').replace(/temp0123/g, '% ');
+      params.query_term.includes('720p') ? (params.query_term = params.query_term.replace(/720p/g, ''), params.quality = '720p') : null;
+      params.query_term.includes('1080p') ? (params.query_term = params.query_term.replace(/1080p/g, ''), params.quality = '1080p') : null;
+      params.query_term.includes('2160p') ? (params.query_term = params.query_term.replace(/2160p/g, ''), params.quality = '2160p') : null;
+      params.query_term.includes('3D') ? (params.query_term = params.query_term.replace(/3D/g, ''), params.quality = '3D') : null;
     }
     if (filters.genre && filters.genre !== 'All') {
       params.genre = filters.genre;


### PR DESCRIPTION
~~Ability to include the quality as a search term for YTS API (valid terms are `720p`, `1080p`, `2160p` & `3D`)~~

*this was reverted with #1941 and quality added as 'Type' filter instead.