### PR TITLE
More accurate error message when API unreachable

### DIFF
--- a/src/app/lib/models/generic_collection.js
+++ b/src/app/lib/models/generic_collection.js
@@ -30,7 +30,6 @@
             .catch(function (err) {
                 collection.state = 'error';
                 collection.trigger('loaded', collection, collection.state);
-                console.error('PopCollection.fetch() : torrentPromises mapping', err);
             });
 
         return deferred.promise;

--- a/src/app/lib/views/browser/list.js
+++ b/src/app/lib/views/browser/list.js
@@ -97,9 +97,22 @@
             case 'shows':
             case 'anime':
                 if (this.collection.state === 'error') {
+                    switch (App.currentview) {
+                    case 'movies':
+                        var errorURL = App.Config.getProviderForType('movie')[0].apiURL[0];
+                        break;
+                    case 'shows':
+                        var errorURL = App.Config.getProviderForType('tvshow')[0].apiURL[0];
+                        break;
+                    case 'anime':
+                        var errorURL = App.Config.getProviderForType('anime')[0].apiURL[0];
+                        break;
+                    default:
+                        var errorURL;
+                    }
                     return ErrorView.extend({
                         retry: true,
-                        error: i18n.__('The remote ' + App.currentview + ' API failed to respond, please check %s and try again later', '<a class="links" href="' + Settings.statusUrl + '">' + Settings.statusUrl + '</a>')
+                        error: i18n.__('The remote ' + App.currentview + ' API failed to respond, please check %s and try again later', '<a class="links" href="' + errorURL + '">' + errorURL + '</a>')
                     });
                 } else if (this.collection.state !== 'loading') {
                     return ErrorView.extend({


### PR DESCRIPTION
It will now display the current API url you are trying to reach in the specific tab, custom or default, instead of status.popcorntime.app which hasn't worked for some time now.