### PR TITLE
Fix textboxes right click 'Paste' weird behavior

### DIFF
--- a/src/app/lib/views/browser/filter_bar.js
+++ b/src/app/lib/views/browser/filter_bar.js
@@ -156,8 +156,7 @@
         paste = new nw.MenuItem({
           label: pasteLabel || 'Paste',
           click: function() {
-            var text = clipboard.get('text');
-            $('#searchbox').val(text);
+            document.execCommand('paste');
           }
         });
 

--- a/src/app/lib/views/seedbox.js
+++ b/src/app/lib/views/seedbox.js
@@ -83,8 +83,7 @@
 				paste = new nw.MenuItem({
 					label: pasteLabel || 'Paste',
 					click: function () {
-						var text = clipboard.get('text');
-						$('#online-input').val(text);
+						document.execCommand('paste');
 					}
 				});
 

--- a/src/app/lib/views/settings_container.js
+++ b/src/app/lib/views/settings_container.js
@@ -111,8 +111,7 @@
                 paste = new nw.MenuItem({
                     label: pasteLabel || 'Paste',
                     click: function () {
-                        var text = clipboard.get('text');
-                        $('#' + field).val(text);
+                        document.execCommand('paste');
                     }
                 });
 

--- a/src/app/lib/views/torrent_collection.js
+++ b/src/app/lib/views/torrent_collection.js
@@ -417,8 +417,7 @@
                 paste = new nw.MenuItem({
                     label: pasteLabel || 'Paste',
                     click: function () {
-                        var text = clipboard.get('text');
-                        $('#online-input').val(text);
+                        document.execCommand('paste');
                     }
                 });
 


### PR DESCRIPTION
Instead of the conventional paste behavior you'd expect from a textbox it was erasing all the current input, highlighted or not, and completely replacing it with whatever you had in clipboard. Now it just uses the native method and does what paste normally does.

This was also sometimes causing some textboxes to not register the change (e.g the 'API Server' ones in the settings). Also now resolved.