### PR TITLE
Fix multiple term search

### DIFF
--- a/src/app/butter-provider/anime.js
+++ b/src/app/butter-provider/anime.js
@@ -135,7 +135,7 @@ AnimeApi.prototype.fetch = function(filters) {
   params.limit = '50';
 
   if (filters.keywords) {
-    params.keywords = filters.keywords.replace(/\s/g, '% ').replace(/[^a-zA-Z0-9]/g,' ');
+    params.keywords = filters.keywords.replace(/[^a-zA-Z0-9]|\s/g, '% ');
   }
 
   if (filters.genre) {

--- a/src/app/butter-provider/movie.js
+++ b/src/app/butter-provider/movie.js
@@ -94,7 +94,7 @@ class MovieApi extends Generic {
     };
 
     if (filters.keywords) {
-      params.keywords = filters.keywords.replace(/\s/g, '% ').replace(/[^a-zA-Z0-9]/g,' ');
+      params.keywords = filters.keywords.replace(/[^a-zA-Z0-9]|\s/g, '% ');
     }
     if (filters.genre) {
       params.genre = filters.genre;

--- a/src/app/butter-provider/tv.js
+++ b/src/app/butter-provider/tv.js
@@ -68,7 +68,7 @@ class TVApi extends Generic {
     };
 
     if (filters.keywords) {
-      params.keywords = filters.keywords.replace(/\s/g, '% ').replace(/[^a-zA-Z0-9]/g,' ');
+      params.keywords = filters.keywords.replace(/[^a-zA-Z0-9]|\s/g, '% ');
     }
     if (filters.genre) {
       params.genre = filters.genre;


### PR DESCRIPTION
https://github.com/popcorn-official/popcorn-desktop/pull/1937 broke the search when using multiple terms on some APIs (e.g RU one). This fixes it again while keeping the better location for the `replace()`