### PR TITLE
Fix special character search for RU API

### DIFF
--- a/src/app/butter-provider/anime.js
+++ b/src/app/butter-provider/anime.js
@@ -135,7 +135,7 @@ AnimeApi.prototype.fetch = function(filters) {
   params.limit = '50';
 
   if (filters.keywords) {
-    params.keywords = filters.keywords.replace(/[^a-zA-Z0-9]|\s/g, '% ');
+    params.keywords = this.apiURL[0].includes('popcorn-ru') ? filters.keywords.replace(/\s/g, '% ') : filters.keywords.replace(/[^a-zA-Z0-9]|\s/g, '% ');
   }
 
   if (filters.genre) {

--- a/src/app/butter-provider/movie.js
+++ b/src/app/butter-provider/movie.js
@@ -94,7 +94,7 @@ class MovieApi extends Generic {
     };
 
     if (filters.keywords) {
-      params.keywords = filters.keywords.replace(/[^a-zA-Z0-9]|\s/g, '% ');
+      params.keywords = this.apiURL[0].includes('popcorn-ru') ? filters.keywords.replace(/\s/g, '% ') : filters.keywords.replace(/[^a-zA-Z0-9]|\s/g, '% ');
     }
     if (filters.genre) {
       params.genre = filters.genre;

--- a/src/app/butter-provider/tv.js
+++ b/src/app/butter-provider/tv.js
@@ -68,7 +68,7 @@ class TVApi extends Generic {
     };
 
     if (filters.keywords) {
-      params.keywords = filters.keywords.replace(/[^a-zA-Z0-9]|\s/g, '% ');
+      params.keywords = this.apiURL[0].includes('popcorn-ru') ? filters.keywords.replace(/\s/g, '% ') : filters.keywords.replace(/[^a-zA-Z0-9]|\s/g, '% ');
     }
     if (filters.genre) {
       params.genre = filters.genre;


### PR DESCRIPTION
It treats special characters in search terms differently than the official API so special characters search with it hasnt worked for some time now, this fixes. (not much else is different as to require a separate provider like YTS does)  

@ivan1986 if you have any comments or edits about this let me know