### PR TITLE
Limit readdirp package to 2.x.x version

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "opensubtitles-api": "5.0.0",
     "q": "2.0.3",
     "querystring": "^0.2.0",
-    "readdirp": "*",
+    "readdirp": "2.x.x",
     "request": "2.88.x",
     "rimraf": "2.x.x",
     "sanitizer": "0.x.x",


### PR DESCRIPTION
The package has breaking changes after that version, and external players do not show in the list.

This fixes issues with external players like VLC. (#1406)
