### PR TITLE
Improve torrent health check

### DIFF
--- a/src/app/common.js
+++ b/src/app/common.js
@@ -61,7 +61,7 @@ Common.retrieveTorrentHealth = function (torrent, cb) {
 	torrentHealth(
 		torrentURL,
 		{
-			timeout: 2000,
+			timeout: 2500,
 			trackers: Settings.trackers.forced
 		},
 		cb
@@ -73,7 +73,7 @@ Common.HealthButton = function (selector, retrieveHealthCallback) {
 		throw new TypeError('This class must be constructed with "new"');
 	}
 
-	const maxChecksWhenNoSeeds = 4;
+	const maxChecksWhenNoSeeds = 3;
 	let zeroSeedCheckCount = 0;
 	let pendingRender = null;
 

--- a/src/app/lib/views/movie_detail.js
+++ b/src/app/lib/views/movie_detail.js
@@ -361,7 +361,7 @@
         if ($('.health-icon ~ .tooltip').is(':visible')) {
           $('.health-icon').tooltip('fixTitle').tooltip('show');
         }
-      }, 2100);
+      }, 2600);
     },
 
     openIMDb: function() {

--- a/src/app/lib/views/seedbox.js
+++ b/src/app/lib/views/seedbox.js
@@ -334,7 +334,7 @@
 				if ($('.seedbox .health-icon ~ .tooltip').is(':visible')) {
 					$('.seedbox .health-icon').tooltip('fixTitle').tooltip('show');
 				}
-			}, 2100);
+			}, 2600);
 		},
 
 		updateView: function ($elem, wasJustSelected = false) {

--- a/src/app/lib/views/show_detail.js
+++ b/src/app/lib/views/show_detail.js
@@ -770,7 +770,7 @@
                 if ($('.health-icon ~ .tooltip').is(':visible')) {
                     $('.health-icon').tooltip('fixTitle').tooltip('show');
                 }
-            }, 2100);
+            }, 2600);
         },
 
         selectPlayer: function (e) {


### PR DESCRIPTION
Changes the maximum 5 retries (includes the first try) to 4 and the 2000ms timeout/retry to 2500ms which gives a little more time for trackers to respond and in the end more accurate data. (and possibly less retries needed to get something back so less total time)