### PR TITLE
Add 'Show the Seedbox when adding a new download' option

### DIFF
--- a/src/app/language/en.json
+++ b/src/app/language/en.json
@@ -551,5 +551,7 @@
 	"Never": "Never",
 	"Ask me every time": "Ask me every time",
 	"Enable Protocol Encryption": "Enable Protocol Encryption",
-	"Allows connecting to peers that use PE/MSE. Will in most cases increase the number of connectable peers but might also result in increased CPU usage": "Allows connecting to peers that use PE/MSE. Will in most cases increase the number of connectable peers but might also result in increased CPU usage"
+	"Allows connecting to peers that use PE/MSE. Will in most cases increase the number of connectable peers but might also result in increased CPU usage": "Allows connecting to peers that use PE/MSE. Will in most cases increase the number of connectable peers but might also result in increased CPU usage",
+	"Show the Seedbox screen when adding a new download": "Show the Seedbox screen when adding a new download",
+	"Download added": "Download added"
 }

--- a/src/app/language/en.json
+++ b/src/app/language/en.json
@@ -552,6 +552,6 @@
 	"Ask me every time": "Ask me every time",
 	"Enable Protocol Encryption": "Enable Protocol Encryption",
 	"Allows connecting to peers that use PE/MSE. Will in most cases increase the number of connectable peers but might also result in increased CPU usage": "Allows connecting to peers that use PE/MSE. Will in most cases increase the number of connectable peers but might also result in increased CPU usage",
-	"Show the Seedbox screen when adding a new download": "Show the Seedbox screen when adding a new download",
+	"Show the Seedbox when adding a new download": "Show the Seedbox when adding a new download",
 	"Download added": "Download added"
 }

--- a/src/app/lib/views/play_control.js
+++ b/src/app/lib/views/play_control.js
@@ -228,12 +228,16 @@
         : defaultTorrent;
 
       App.vent.trigger('stream:download', torrent, this.model.get('title') /*mediaName*/);
-      App.previousview = App.currentview;
-      App.currentview = 'Seedbox';
-      App.vent.trigger('seedbox:show');
-      $('.filter-bar').find('.active').removeClass('active');
-      $('#filterbar-seedbox').addClass('active');
-      $('#nav-filters').hide();
+      if (Settings.showSeedboxOnDlInit) {
+        App.previousview = App.currentview;
+        App.currentview = 'Seedbox';
+        App.vent.trigger('seedbox:show');
+        $('.filter-bar').find('.active').removeClass('active');
+        $('#filterbar-seedbox').addClass('active');
+        $('#nav-filters').hide();
+      } else {
+        $('.notification_alert').stop().text(i18n.__('Download added')).fadeIn('fast').delay(1500).fadeOut('fast');
+      }
     },
 
     startStreaming: function() {

--- a/src/app/lib/views/settings_container.js
+++ b/src/app/lib/views/settings_container.js
@@ -287,6 +287,7 @@
                 case 'vpnEnabled':
                 case 'coversShowRating':
                 case 'torColSearchMore':
+                case 'showSeedboxOnDlInit':
                 case 'nativeWindowFrame':
                 case 'translateSynopsis':
                 case 'showAdvancedSettings':

--- a/src/app/lib/views/show_detail.js
+++ b/src/app/lib/views/show_detail.js
@@ -528,12 +528,16 @@
           const torrent = $(e.currentTarget).attr('data-torrent');
           const file = $(e.currentTarget).attr('data-file');
           App.vent.trigger('stream:download', torrent, this.model.get('title'), file);
-          App.previousview = App.currentview;
-          App.currentview = 'Seedbox';
-          App.vent.trigger('seedbox:show');
-          $('.filter-bar').find('.active').removeClass('active');
-          $('#filterbar-seedbox').addClass('active');
-          $('#nav-filters').hide();
+          if (Settings.showSeedboxOnDlInit) {
+            App.previousview = App.currentview;
+            App.currentview = 'Seedbox';
+            App.vent.trigger('seedbox:show');
+            $('.filter-bar').find('.active').removeClass('active');
+            $('#filterbar-seedbox').addClass('active');
+            $('#nav-filters').hide();
+          } else {
+            $('.notification_alert').stop().text(i18n.__('Download added')).fadeIn('fast').delay(1500).fadeOut('fast');
+          }
         },
 
         closeDetails: function (e) {

--- a/src/app/settings.js
+++ b/src/app/settings.js
@@ -132,6 +132,7 @@ Settings.defaultFilters = 'default';
 Settings.moviesTabEnable = true;
 Settings.seriesTabEnable = true;
 Settings.animeTabEnable = true;
+Settings.showSeedboxOnDlInit = true;
 
 // Quality
 Settings.shows_default_quality = '720p';

--- a/src/app/templates/settings-container.tpl
+++ b/src/app/templates/settings-container.tpl
@@ -114,7 +114,7 @@
             <% if (Settings.activateSeedbox) { %>
             <span class="advanced">
                 <input class="settings-checkbox" name="showSeedboxOnDlInit" id="showSeedboxOnDlInit" type="checkbox" <%=(Settings.showSeedboxOnDlInit? "checked='checked'":"")%>>
-                <label class="settings-label" for="showSeedboxOnDlInit"><%= i18n.__("Show the Seedbox screen when adding a new download") %></label>
+                <label class="settings-label" for="showSeedboxOnDlInit"><%= i18n.__("Show the Seedbox when adding a new download") %></label>
             </span>
             <% } %>
             <span class="advanced">

--- a/src/app/templates/settings-container.tpl
+++ b/src/app/templates/settings-container.tpl
@@ -105,10 +105,18 @@
                 <input class="settings-checkbox" name="moviesShowQuality" id="moviesShowQuality" type="checkbox" <%=(Settings.moviesShowQuality? "checked='checked'":"")%>>
                 <label class="settings-label" for="moviesShowQuality"><%= i18n.__("Show movie quality on list") %></label>
             </span>
+            <% if (Settings.activateTorrentCollection) { %>
             <span class="advanced">
                 <input class="settings-checkbox" name="torColSearchMore" id="torColSearchMore" type="checkbox" <%=(Settings.torColSearchMore? "checked='checked'":"")%>>
                 <label class="settings-label" for="torColSearchMore"><%= i18n.__("Show 'Search on Torrent Collection' in search") %></label>
             </span>
+            <% } %>
+            <% if (Settings.activateSeedbox) { %>
+            <span class="advanced">
+                <input class="settings-checkbox" name="showSeedboxOnDlInit" id="showSeedboxOnDlInit" type="checkbox" <%=(Settings.showSeedboxOnDlInit? "checked='checked'":"")%>>
+                <label class="settings-label" for="showSeedboxOnDlInit"><%= i18n.__("Show the Seedbox screen when adding a new download") %></label>
+            </span>
+            <% } %>
             <span class="advanced">
                 <div class="dropdown defaultFilters">
                     <p><%= i18n.__("Default Filters") %></p>


### PR DESCRIPTION
By default this is enabled so it will still show the Seedbox screen when adding a new download like before but users who prefer to stay on the movie/episode screen they were at now have the option. When disabled it will just display a brief notification that the download was added instead of switching to the Seedbox.