### PR TITLE
Streamer fix

### DIFF
--- a/src/app/lib/streamer.js
+++ b/src/app/lib/streamer.js
@@ -154,67 +154,32 @@
             }.bind(this));
         },
 
-        // kill the streamer
         stop: function() {
             if (this.torrent) {
+                const removedPeers = [];
+
                 // update ratio
                 AdvSettings.set('totalDownloaded', Settings.totalDownloaded + this.torrent.downloaded);
                 AdvSettings.set('totalUploaded', Settings.totalUploaded + this.torrent.uploaded);
 
-                if (Settings.activateSeedbox) {
-                    this.torrent.pause();
-                    // complete pause torrent, stop download data
-                    const removedPeers = [];
-                    for (const id in this.torrent._peers) {
-                        // collect peers, need to do this before calling removePeer!
-                        removedPeers.push(this.torrent._peers[id].addr);
+                this.torrent.pause();
 
-                        this.torrent.removePeer(id);
-                    }
-                    if(removedPeers.length > 0) {
-                        // store removed peers, so we can re-add them when resuming
-                        this.torrent.pctRemovedPeers = removedPeers;
-                    }
-
-                    if (this.torrent._xsRequests) {
-                        this.torrent._xsRequests.forEach(req => {
-                            req.abort();
-                        });
-                    }
-                } else {
-                    this.torrent.destroy();
+                for (const id in this.torrent._peers) {
+                    // collect peers, need to do this before calling removePeer!
+                    removedPeers.push(this.torrent._peers[id].addr);
+                    this.torrent.removePeer(id);
                 }
-            }
 
-            if (this.video) {
-                this.video.pause();
-                this.video.src = '';
-                this.video.load();
-                this.video = null;
-            }
+                if(removedPeers.length > 0) {
+                    // store removed peers, so we can re-add them when resuming
+                    this.torrent.pctRemovedPeers = removedPeers;
+                }
 
-            this.torrent = null;
-            this.torrentModel = null;
-            this.stateModel = null;
-            this.streamInfo = null;
-            this.subtitleReady = false;
-            this.canPlay = false;
-            this.stopped = true;
-            clearInterval(this.updateStatsInterval);
-            this.updateStatsInterval = null;
-
-            App.vent.off('subtitle:downloaded');
-            App.SubtitlesServer.stop();
-            win.info('Streaming cancelled');
-        },
-
-        stopFS: function() {
-            if (this.torrent) {
-                // update ratio
-                AdvSettings.set('totalDownloaded', Settings.totalDownloaded + this.torrent.downloaded);
-                AdvSettings.set('totalUploaded', Settings.totalUploaded + this.torrent.uploaded);
-
-                this.torrent.destroy();
+                if (this.torrent._xsRequests) {
+                    this.torrent._xsRequests.forEach(req => {
+                        req.abort();
+                    });
+                }
             }
 
             if (this.video) {
@@ -779,7 +744,6 @@
     App.vent.on('stream:loadExistTorrents', streamer.initExistTorrents.bind(streamer));
     App.vent.on('stream:start', streamer.start.bind(streamer));
     App.vent.on('stream:stop', streamer.stop.bind(streamer));
-    App.vent.on('stream:stopFS', streamer.stopFS.bind(streamer));
     App.vent.on('stream:download', streamer.download.bind(streamer));
     App.vent.on('stream:serve_subtitles', streamer.serveSubtitles.bind(streamer));
 })(window.App);

--- a/src/app/lib/views/main_window.js
+++ b/src/app/lib/views/main_window.js
@@ -539,7 +539,7 @@
 
     showFileSelector: function(fileModel) {
       App.vent.trigger('about:close');
-      App.vent.trigger('stream:stopFS');
+      App.vent.trigger('stream:stop');
       App.vent.trigger('player:close');
       this.showChildView(
         'FileSelector',


### PR DESCRIPTION
The issue is that peers don't resolve or are being re-added after restarting a torrent with the Seedbox feature disabled or if you are using the Torrent Collection or importing an external magnet link (so the file selector is displayed).

#2042 solved that for when the Seedbox is enabled and when the file selector isn't displayed. This PR adds the same functionality to everything else to solve the issue above.