### PR TITLE
Streamer fix

### DIFF
--- a/src/app/app.js
+++ b/src/app/app.js
@@ -95,10 +95,11 @@ App.advsettings = AdvSettings;
 App.settings = Settings;
 App.WebTorrent = new WebTorrent({
   maxConns: parseInt(Settings.connectionLimit, 10) || 55,
-  tracker: {
-     announce: Settings.trackers.forced
-  },
   dht: true,
+  secure: Settings.protocolEncryption || false,
+  tracker: {
+    announce: Settings.trackers.forced
+  }
 });
 
 App.plugins = {};

--- a/src/app/lib/views/main_window.js
+++ b/src/app/lib/views/main_window.js
@@ -539,7 +539,7 @@
 
     showFileSelector: function(fileModel) {
       App.vent.trigger('about:close');
-      App.vent.trigger('stream:stop');
+      App.vent.trigger('stream:stopFS');
       App.vent.trigger('player:close');
       this.showChildView(
         'FileSelector',


### PR DESCRIPTION
Adds to #2224. Now if the Seedbox feature is disabled when canceling a stream App.WebTorrent.destroy() is called which resolves the peers on resume issue. The fileselector logic remains as it was with #2224, using a Seedbox-style stop (pause) no matter if the Seedbox is enabled or not.