### PR TITLE
Sourcelink tooltip fix

### DIFF
--- a/src/app/language/en.json
+++ b/src/app/language/en.json
@@ -568,6 +568,5 @@
 	"Only show content available in the preferred language": "Only show content available in the preferred language",
 	"Translations depend on availability. Also some options might not be supported by some API servers": "Translations depend on availability. Also some options might not be supported by some API servers",
 	"added": "added",
-	"Source link": "Source link",
 	"The source link was copied to the clipboard": "The source link was copied to the clipboard"
 }

--- a/src/app/lib/views/movie_detail.js
+++ b/src/app/lib/views/movie_detail.js
@@ -84,9 +84,10 @@
     },
 
     toggleSourceLink: function(quality) {
-      const torrents = this.model.get('torrents');
-      if (torrents[quality].source) {
-        $('.source-link').show();
+      const torrents = this.model.get('torrents'),
+            sourceLink = torrents[quality].source;
+      if (sourceLink) {
+        $('.source-link').show().attr('data-original-title', sourceLink.split('//').pop().split('/')[0]);
       } else {
         $('.source-link').hide();
       }

--- a/src/app/lib/views/movie_detail.js
+++ b/src/app/lib/views/movie_detail.js
@@ -84,10 +84,9 @@
     },
 
     toggleSourceLink: function(quality) {
-      const torrents = this.model.get('torrents'),
-            sourceLink = torrents[quality].source;
-      if (sourceLink) {
-        $('.source-link').show().attr('data-original-title', sourceLink.split('//').pop().split('/')[0]);
+      const sourceURL = this.model.get('torrents')[this.model.get('quality')].source;
+      if (sourceURL) {
+        $('.source-link').show().attr('data-original-title', sourceURL.split('//').pop().split('/')[0]);
       } else {
         $('.source-link').hide();
       }

--- a/src/app/lib/views/show_detail.js
+++ b/src/app/lib/views/show_detail.js
@@ -898,7 +898,7 @@
         toggleSourceLink: function () {
             const sourceURL = $('.startStreaming').attr('data-source');
             if (sourceURL) {
-                $('.source-icon').show();
+                $('.source-icon').show().attr('data-original-title', sourceURL.split('//').pop().split('/')[0]);
             } else {
                 $('.source-icon').hide();
             }

--- a/src/app/templates/movie-detail.tpl
+++ b/src/app/templates/movie-detail.tpl
@@ -54,7 +54,7 @@ if (genre) {
             </div>
             <div data-toggle="tooltip" data-placement="left" title="<%=i18n.__("Health false") %>" class="fa fa-circle health-icon <%= health %>"></div>
             <div data-toogle="tooltip" data-placement="left" title="<%=i18n.__("Magnet link") %>" class="fa fa-magnet magnet-link"></div>
-            <div data-toogle="tooltip" data-placement="left" title="<%=i18n.__("Source link") %>" class="fas fa-link source-link"></div>
+            <div data-toogle="tooltip" data-placement="left" title="" class="fas fa-link source-link"></div>
 
         </div>
 

--- a/src/app/templates/show-detail.tpl
+++ b/src/app/templates/show-detail.tpl
@@ -106,7 +106,7 @@
             <div class="sdo-infos">
                 <div class="sdoi-title"></div>
                 <div class="sdoi-links">
-                    <div data-toggle="tooltip" data-placement="left" title="<%=i18n.__('Source link') %>" class="fas fa-link source-icon"></div>
+                    <div data-toggle="tooltip" data-placement="left" title="" class="fas fa-link source-icon"></div>
                     <div data-toggle="tooltip" data-placement="left" title="<%=i18n.__('Magnet link') %>" class="fa fa-magnet magnet-icon"></div>
                     <div data-toggle="tooltip" data-placement="left" title="<%=i18n.__('Health Unknown') %>" class="fa fa-circle health-icon None"></div>
                 </div>


### PR DESCRIPTION
Adds the domain as tooltip text instead of 'Source link'.