### PR TITLE
Adjustable next episode preload time

### DIFF
--- a/src/app/language/en.json
+++ b/src/app/language/en.json
@@ -582,5 +582,6 @@
 	"was added to bookmarks": "was added to bookmarks",
 	"was removed from bookmarks": "was removed from bookmarks",
 	"Bookmark restored": "Bookmark restored",
-	"Undo": "Undo"
+	"Undo": "Undo",
+	"Remaining runtime before start preloading next episode": "Remaining runtime before start preloading next episode"
 }

--- a/src/app/lib/views/player/player.js
+++ b/src/app/lib/views/player/player.js
@@ -258,7 +258,7 @@
 
         checkAutoPlay: function () {
             if (this.isMovie() === 'episode' && this.next_episode_model) {
-                if ((this.video.duration() - this.video.currentTime()) < 60 && this.video.currentTime() > 30) {
+                if ((this.video.duration() - this.video.currentTime()) < (Settings.preloadNextEpisodeTime * 60) && this.video.currentTime() > 30) {
 
                     if (!this.autoplayisshown) {
                         var playingNext = $('.playing_next');
@@ -268,12 +268,14 @@
                             this.precachestarted = true;
                         }
 
-                        win.info('Showing Auto Play message');
-                        this.autoplayisshown = true;
-                        playingNext.show();
-                        playingNext.appendTo('div#video_player');
-                        if (!this.player.userActive()) {
-                            this.player.userActive(true);
+                        if ((this.video.duration() - this.video.currentTime()) < 60) {
+                            win.info('Showing Auto Play message');
+                            this.autoplayisshown = true;
+                            playingNext.show();
+                            playingNext.appendTo('div#video_player');
+                            if (!this.player.userActive()) {
+                                this.player.userActive(true);
+                            }
                         }
                     }
 

--- a/src/app/lib/views/settings_container.js
+++ b/src/app/lib/views/settings_container.js
@@ -365,6 +365,14 @@
                     value = nvalue;
                     win.zoomLevel = Math.log(value/100) / Math.log(1.2);
                     break;
+                case 'preloadNextEpisodeTime':
+                    let nnvalue = field.val().replace(/[^0-9]/gi, '');
+                    if (!nnvalue || nnvalue <= 0) {
+                        nnvalue = 1;
+                    }
+                    field.val(nnvalue);
+                    value = nnvalue;
+                    break;
                 case 'tmpLocation':
                     tmpLocationChanged = true;
                     value = field.val();
@@ -576,6 +584,7 @@
                 case 'torColSearchMore':
                 case 'httpApiEnabled':
                 case 'showSubmitMeta':
+                case 'playNextEpisodeAuto':
                     $('.nav-hor.left li:first').click();
                     App.vent.trigger('settings:show');
                     break;

--- a/src/app/settings.js
+++ b/src/app/settings.js
@@ -127,6 +127,7 @@ Settings.translateEpisodes = true;
 //Playback
 Settings.alwaysFullscreen = false;
 Settings.playNextEpisodeAuto = false;
+Settings.preloadNextEpisodeTime = 1;
 Settings.activateLoCtrl = false;
 Settings.chosenPlayer = 'local';
 

--- a/src/app/templates/settings-container.tpl
+++ b/src/app/templates/settings-container.tpl
@@ -408,6 +408,12 @@
                 <input class="settings-checkbox" name="playNextEpisodeAuto" id="playNextEpisodeAuto" type="checkbox" <%=(Settings.playNextEpisodeAuto? "checked='checked'":"")%>>
                 <label class="settings-label" for="playNextEpisodeAuto"><%= i18n.__("Play next episode automatically") %></label>
             </span>
+            <% if (Settings.playNextEpisodeAuto) { %>
+            <span class="advanced">
+                <p><%= i18n.__("Remaining runtime before start preloading next episode") %>&nbsp;&nbsp;</p>
+                <input id="preloadNextEpisodeTime" type="text" size="5" name="preloadNextEpisodeTime" value="<%=Settings.preloadNextEpisodeTime%>" autocomplete="off"/>&nbsp;&nbsp;&nbsp;<em><%= i18n.__("minute(s)") %></em>
+            </span>
+            <% } %>
         </div>
     </section>
 


### PR DESCRIPTION
By default if you have 'Play next episode automatically' enabled Popcorn Time starts preloading the next episode 1 minute before the current one ends. This turns this into a variable and exposes it in the settings page so the preload time can be changed to any integer (in minutes). 

&nbsp;
*&nbsp;If the set value is bigger than the runtime of the episode it starts preloading 30 seconds after playback starts to avoid having both episodes start downloading at the exact same time.
**&nbsp;The popup notification that was shown to 'Play now' or 'Cancel autoplay' remains at the fixed 1 minute before playback ends.
***&nbsp;'Play next episode automatically' needs to be enabled for this option to be available since its directly depended on it.