### PR TITLE
Some visual tweaks

### DIFF
--- a/make_popcorn.sh
+++ b/make_popcorn.sh
@@ -122,7 +122,7 @@ if [ "$rd_dep" = "yes" ]; then
     echo "Successfully setup for Popcorn Time"
 fi
 
-if gulp build; then
+if yarn build; then
     echo "Popcorn Time built successfully!"
     if [[ `uname -s` != *"NT"* ]]; then # if not windows
         ./Create-Desktop-Entry

--- a/src/app/lib/views/seedbox.js
+++ b/src/app/lib/views/seedbox.js
@@ -109,11 +109,11 @@
                     <div id="title-${torrent.infoHash}">${App.plugins.mediaName.getMediaName(torrent)}</div>
                 </a>
 
-                <i class="fa fa-trash watched trash-torrent tooltipped" id="trash-${torrent.infoHash}" title="Remove" data-toggle="tooltip" data-placement="left"></i>
-                <i class="fa fa-play watched resume-torrent tooltipped" id="play-${torrent.infoHash}"  title="Resume" data-toggle="tooltip" data-placement="left" style="display: ${torrent.paused ? '' : 'none'};"></i>
+                <i class="fa fa-download watched"></i><span id="download-${torrent.infoHash}"> 0 Kb/s</span>
+                <i class="fa fa-upload watched"></i><span id="upload-${torrent.infoHash}"> 0 Kb/s</span>
                 <i class="fa fa-pause-circle watched pause-torrent tooltipped" id="resume-${torrent.infoHash}"  title="Pause" data-toggle="tooltip" data-placement="left" style="display: ${torrent.paused ? 'none' : ''};"></i>
-                <i class="fa fa-upload watched" id="upload-${torrent.infoHash}"> 0 Kb/s</i>
-                <i class="fa fa-download watched" id="download-${torrent.infoHash}"> 0 Kb/s</i>
+                <i class="fa fa-play watched resume-torrent tooltipped" id="play-${torrent.infoHash}"  title="Resume" data-toggle="tooltip" data-placement="left" style="display: ${torrent.paused ? '' : 'none'};"></i>
+                <i class="fa fa-trash watched trash-torrent tooltipped" id="trash-${torrent.infoHash}" title="Remove" data-toggle="tooltip" data-placement="left"></i>
               </li>`
 			);
 

--- a/src/app/lib/views/seedbox.js
+++ b/src/app/lib/views/seedbox.js
@@ -109,8 +109,8 @@
                     <div id="title-${torrent.infoHash}">${App.plugins.mediaName.getMediaName(torrent)}</div>
                 </a>
 
-                <i class="fa fa-download watched"></i><span id="download-${torrent.infoHash}"> 0 Kb/s</span>
-                <i class="fa fa-upload watched"></i><span id="upload-${torrent.infoHash}"> 0 Kb/s</span>
+                <i class="fa fa-download watched"></i><small id="download-${torrent.infoHash}"> 0 Kb/s</small>
+                <i class="fa fa-upload watched"></i><small id="upload-${torrent.infoHash}"> 0 Kb/s</small>
                 <i class="fa fa-pause-circle watched pause-torrent tooltipped" id="resume-${torrent.infoHash}"  title="Pause" data-toggle="tooltip" data-placement="left" style="display: ${torrent.paused ? 'none' : ''};"></i>
                 <i class="fa fa-play watched resume-torrent tooltipped" id="play-${torrent.infoHash}"  title="Resume" data-toggle="tooltip" data-placement="left" style="display: ${torrent.paused ? '' : 'none'};"></i>
                 <i class="fa fa-trash watched trash-torrent tooltipped" id="trash-${torrent.infoHash}" title="Remove" data-toggle="tooltip" data-placement="left"></i>

--- a/src/app/lib/views/seedbox.js
+++ b/src/app/lib/views/seedbox.js
@@ -13,12 +13,12 @@
 
 	var formatBytes = function (bytes, decimals) {
 		if (bytes === 0) {
-			return '0 Bytes';
+			return '0 B';
 		}
 
 		let k = 1024,
 			dm = decimals || 2,
-			sizes = ['Bytes', 'KB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB'],
+			sizes = ['B', 'KB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB'],
 			i = Math.floor(Math.log(bytes) / Math.log(k));
 		return parseFloat((bytes / Math.pow(k, i)).toFixed(dm)) + ' ' + sizes[i];
 	};

--- a/src/app/lib/views/seedbox.js
+++ b/src/app/lib/views/seedbox.js
@@ -464,7 +464,7 @@
 					totalSize = totalSize + file.length;
 					totalDownloaded = totalDownloaded + file.downloaded;
 					try {
-						let thisElement = document.evaluate("//a[text()='" + file.name + "']", document, null, XPathResult.FIRST_ORDERED_NODE_TYPE, null).singleNodeValue.parentNode;
+						const thisElement = document.evaluate(`//a[text()='${file.name}']`, document, null, XPathResult.FIRST_ORDERED_NODE_TYPE, null).singleNodeValue.parentNode;
 						$(thisElement).attr('title', Common.fileSize(file.downloaded) + ' / ' + Common.fileSize(file.length)).tooltip('fixTitle');
 					} catch(err) {}
 				}

--- a/src/app/lib/views/seedbox.js
+++ b/src/app/lib/views/seedbox.js
@@ -17,7 +17,7 @@
 		}
 
 		let k = 1024,
-			dm = decimals || 2,
+			dm = decimals || 1,
 			sizes = ['B', 'KB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB'],
 			i = Math.floor(Math.log(bytes) / Math.log(k));
 		return (bytes / Math.pow(k, i)).toFixed(dm) + ' ' + sizes[i];

--- a/src/app/lib/views/seedbox.js
+++ b/src/app/lib/views/seedbox.js
@@ -20,7 +20,7 @@
 			dm = decimals || 2,
 			sizes = ['B', 'KB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB'],
 			i = Math.floor(Math.log(bytes) / Math.log(k));
-		return parseFloat((bytes / Math.pow(k, i)).toFixed(dm)) + ' ' + sizes[i];
+		return (bytes / Math.pow(k, i)).toFixed(dm) + ' ' + sizes[i];
 	};
 
 	var Seedbox = Marionette.View.extend({

--- a/src/app/lib/views/seedbox.js
+++ b/src/app/lib/views/seedbox.js
@@ -109,8 +109,8 @@
                     <div id="title-${torrent.infoHash}">${App.plugins.mediaName.getMediaName(torrent)}</div>
                 </a>
 
-                <i class="fa fa-download watched"></i><small id="download-${torrent.infoHash}"> 0 Kb/s</small>
-                <i class="fa fa-upload watched"></i><small id="upload-${torrent.infoHash}"> 0 Kb/s</small>
+                <i class="fa fa-download watched" id="download-${torrent.infoHash}">0 Kb/s</i>
+                <i class="fa fa-upload watched" id="upload-${torrent.infoHash}">0 Kb/s</i>
                 <i class="fa fa-pause-circle watched pause-torrent tooltipped" id="resume-${torrent.infoHash}"  title="Pause" data-toggle="tooltip" data-placement="left" style="display: ${torrent.paused ? 'none' : ''};"></i>
                 <i class="fa fa-play watched resume-torrent tooltipped" id="play-${torrent.infoHash}"  title="Resume" data-toggle="tooltip" data-placement="left" style="display: ${torrent.paused ? '' : 'none'};"></i>
                 <i class="fa fa-trash watched trash-torrent tooltipped" id="trash-${torrent.infoHash}" title="Remove" data-toggle="tooltip" data-placement="left"></i>

--- a/src/app/styl/views/seedbox.styl
+++ b/src/app/styl/views/seedbox.styl
@@ -28,7 +28,8 @@
 
           .seedbox-types ul, .seedbox-torrents ul
               height: calc(100vh - 167px)
-              direction: rtl
+              /* direction: rtl */
+              text-align: right
               scrollable()
 
               li

--- a/src/app/styl/views/seedbox.styl
+++ b/src/app/styl/views/seedbox.styl
@@ -39,6 +39,9 @@
                   width: calc(100% - 7px)
                   cursor: pointer
 
+                  small
+                      font-size: 85%
+
                   .watched
                       padding 10px 0
                       color: $ShowWatchedIcon_false

--- a/src/app/styl/views/seedbox.styl
+++ b/src/app/styl/views/seedbox.styl
@@ -39,9 +39,6 @@
                   width: calc(100% - 7px)
                   cursor: pointer
 
-                  small
-                      font-size: 85%
-
                   .watched
                       padding 10px 0
                       color: $ShowWatchedIcon_false

--- a/src/app/styl/views/seedbox.styl
+++ b/src/app/styl/views/seedbox.styl
@@ -44,7 +44,7 @@
                       color: $ShowWatchedIcon_false
                       transition color .5s
                       font-size: 0.9em
-                      font-family: "Font Awesome 5 Free", "Open Sans SemiBold"
+                      font-family: "Font Awesome 5 Free", $MainFont
 
                       &.true
                           color: $ShowWatchedIcon_true
@@ -259,7 +259,7 @@
 
                       i
                           margin-right: 5px
-                          font-family: "Font Awesome 5 Free", "Open Sans SemiBold"
+                          font-family: "Font Awesome 5 Free", $MainFont
 
                   .seedbox-infos-synopsis
                       color: $ShowText1

--- a/src/app/templates/seedbox.tpl
+++ b/src/app/templates/seedbox.tpl
@@ -20,9 +20,9 @@
                         <div data-toggle="tooltip" data-placement="left" title="<%=i18n.__('Health Unknown') %>" class="fa fa-circle health-icon None tooltipped"></div>
                     </div>
                     <div class="seedbox-infos-aired">
-                        <i class="fa fa-hdd watched"></i><span class="seedbox-totalsize"></span>
-                        <i class="fa fa-download watched"></i><span class="seedbox-downloaded"></span>
-                        <i class="fa fa-upload watched"></i><span class="seedbox-uploaded"></span>
+                        <i class="fa fa-hdd watched seedbox-totalsize"></i>
+                        <i class="fa fa-download watched seedbox-downloaded"></i>
+                        <i class="fa fa-upload watched seedbox-uploaded"></i>
                         <span class="seedbox-infos-date"></span>
                     </div>
                     <div class="seedbox-infos-synopsis">

--- a/src/app/templates/seedbox.tpl
+++ b/src/app/templates/seedbox.tpl
@@ -20,9 +20,9 @@
                         <div data-toggle="tooltip" data-placement="left" title="<%=i18n.__('Health Unknown') %>" class="fa fa-circle health-icon None tooltipped"></div>
                     </div>
                     <div class="seedbox-infos-aired">
-                        <i class="fa fa-hdd watched seedbox-totalsize"></i>
-                        <i class="fa fa-download watched seedbox-downloaded"></i>
-                        <i class="fa fa-upload watched seedbox-uploaded"></i>
+                        <i class="fa fa-hdd watched"></i><span class="seedbox-totalsize"></span>
+                        <i class="fa fa-download watched"></i><span class="seedbox-downloaded"></span>
+                        <i class="fa fa-upload watched"></i><span class="seedbox-uploaded"></span>
                         <span class="seedbox-infos-date"></span>
                     </div>
                     <div class="seedbox-infos-synopsis">


### PR DESCRIPTION
- A minor fix for `make_popcorn.sh` (now developer does not need `gulp` installed globally)

Some minor fixes to the upload/download rates:

- Because the text was inside the icon's `<i>` tag, it was rendering in Serif font, yuck!
- To avoid visual resizing, it now shows up/down rates at a more consistent size
  Old: 312.34 Bytes/s
  New: 312.3 B/s
- Color the unclickable icons differently from the clickable icons
- The "Green" (actually dark gray) in the Flak theme was too dark, so I lightened it a little

Before (FlaX theme):

![Screenshot_20220204_155208](https://user-images.githubusercontent.com/911799/152491960-d8baf956-537a-4786-a083-5a805e67cfee.png)

After (FlaX theme):

![Screenshot_20220204_154927](https://user-images.githubusercontent.com/911799/152491621-724dfb01-850d-4f65-b3dc-740841a0d1f7.png)
