### PR TITLE
Small fix/modification concerning automatic updating

### DIFF
--- a/src/app/language/en.json
+++ b/src/app/language/en.json
@@ -598,5 +598,10 @@
 	"Rotate Hue counter-clockwise by": "Rotate Hue counter-clockwise by",
 	"Rotate Hue clockwise by": "Rotate Hue clockwise by",
 	"Decrease Saturation by": "Decrease Saturation by",
-	"Increase Saturation by": "Increase Saturation by"
+	"Increase Saturation by": "Increase Saturation by",
+	"Automatically update the API Server URLs": "Automatically update the API Server URLs",
+	"Enable automatically updating the API Server URLs": "Enable automatically updating the API Server URLs",
+	"Automatically update the app when a new version is available": "Automatically update the app when a new version is available",
+	"Enable automatically updating the app when a new version is available": "Enable automatically updating the app when a new version is available",
+	"Check for updates": "Check for updates"
 }

--- a/src/app/lib/views/disclaimer.js
+++ b/src/app/lib/views/disclaimer.js
@@ -18,6 +18,8 @@
         acceptDisclaimer: function (e) {
             e.preventDefault();
             Mousetrap.unpause();
+            AdvSettings.set('dhtEnable', document.getElementById('dhtEnableFR').checked ? true : false);
+            AdvSettings.set('automaticUpdating', document.getElementById('automaticUpdatingFR').checked ? true : false);
             AdvSettings.set('disclaimerAccepted', 1);
             App.vent.trigger('disclaimer:close');
         },

--- a/src/app/lib/views/main_window.js
+++ b/src/app/lib/views/main_window.js
@@ -296,7 +296,7 @@
         });
 
         // we check if the disclaimer is accepted
-        if (!AdvSettings.get('disclaimerAccepted')) {
+        if (!AdvSettings.get('disclaimerAccepted') || AdvSettings.get('automaticUpdating') === '' || AdvSettings.get('dhtEnable') === '') {
           that.showDisclaimer();
         }
 

--- a/src/app/lib/views/settings_container.js
+++ b/src/app/lib/views/settings_container.js
@@ -49,6 +49,7 @@
             'click .set-current-filter': 'saveFilter',
             'click .reset-current-filter': 'resetFilter',
             'click .update-dht': 'updateDht',
+            'click .update-app': 'updateApp'
         },
 
         onAttach: function () {
@@ -656,7 +657,11 @@
         },
 
         updateDht: function() {
-            App.DhtReader.update();
+            App.DhtReader.update().catch(function (err) {win.error('dhtReader.update()', err);});;
+        },
+
+        updateApp: function() {
+            App.Updater().update().catch(function (err) {win.error('updater.update()', err);});
         },
 
         connectTrakt: function (e) {

--- a/src/app/settings.js
+++ b/src/app/settings.js
@@ -193,11 +193,11 @@ Settings.delSeedboxCache = 'ask';
 Settings.continueSeedingOnStart = false;
 Settings.vpnEnabled = false;
 Settings.maxActiveTorrents = 5;
-Settings.automaticUpdating = true;
+Settings.automaticUpdating = '';
 Settings.UpdateSeed = false;
+Settings.dhtEnable = ''
 Settings.events = true;
 Settings.minimizeToTray = false;
-Settings.dhtEnable = true;
 
 // Features
 Settings.activateTorrentCollection = true;

--- a/src/app/templates/disclaimer.tpl
+++ b/src/app/templates/disclaimer.tpl
@@ -29,6 +29,14 @@
 
             <p>By using '<%= Settings.projectName %>' or accessing this site you affirm that you are either more than 18 years of age, or an emancipated minor, or possess legal parental or guardian consent, and are fully able and competent to enter into the terms, conditions, obligations, affirmations, representations, and warranties set forth in these Terms of Service, and to abide by and comply with these Terms of Service. In any case, you affirm that you are over the age of 13, as the Service is not intended for children under 13. If you are under 13 years of age, then please do not use the Service. There are lots of other great web sites for you. Talk to your parents about what sites are appropriate for you.</p>
         </div>
+        <span style="font-size: 0.9em;display: block;margin: 8px 0;">
+            <input class="settings-checkbox" name="dhtEnableFR" id="dhtEnableFR" type="checkbox" <%=(Settings.dhtEnable === false ? "":"checked='checked'")%>>
+            <label class="settings-label" for="dhtEnableFR"><%= i18n.__("Enable automatically updating the API Server URLs") %></label>
+        </span>
+        <span style="font-size: 0.9em;display: block;margin: 8px 0;">
+            <input class="settings-checkbox" name="automaticUpdatingFR" id="automaticUpdatingFR" type="checkbox" <%=(Settings.automaticUpdating === false ? "":"checked='checked'")%>>
+            <label class="settings-label" for="automaticUpdatingFR"><%= i18n.__("Enable automatically updating the app when a new version is available") %></label>
+        </span><br>
         <a class="btn-accept"><%= i18n.__("I Accept") %></a> <a class="btn-close"><%= i18n.__("Leave") %></a>
     </div>
 </div>

--- a/src/app/templates/settings-container.tpl
+++ b/src/app/templates/settings-container.tpl
@@ -800,24 +800,24 @@
     <section id="miscellaneous">
         <div class="title"><%= i18n.__("Miscellaneous") %></div>
         <div class="content">
-            <span class="advanced">
-                <input class="settings-checkbox" name="events" id="events" type="checkbox" <%=(Settings.events? "checked='checked'":"")%>>
-                <label class="settings-label" for="events"><%= i18n.__("Celebrate various events") %></label>
+            <span>
+                <input class="settings-checkbox" name="dhtEnable" id="dthEnable" type="checkbox" <%=(Settings.dhtEnable? "checked='checked'":"")%>>
+                <label class="settings-label" for="dhtEnable"><%= i18n.__("Automatically update the API Server URLs") %></label>
+                <i style="margin-left:8px;cursor:pointer" class="update-dht fa fa-redo tooltipped" data-toggle="tooltip" data-placement="auto" title="<%= i18n.__("Check for updates") %>"></i>
             </span>
             <span>
                 <input class="settings-checkbox" name="automaticUpdating" id="automaticUpdating" type="checkbox" <%=(Settings.automaticUpdating? "checked='checked'":"")%>>
-                <label class="settings-label" for="automaticUpdating"><%= i18n.__("Activate automatic updating") %></label>
+                <label class="settings-label" for="automaticUpdating"><%= i18n.__("Automatically update the app when a new version is available") %></label>
+                <i style="margin-left:8px;cursor:pointer" class="update-app fa fa-redo tooltipped" data-toggle="tooltip" data-placement="auto" title="<%= i18n.__("Check for updates") %>"></i>
             </span>
             <span class="advanced">
                 <input class="settings-checkbox" name="UpdateSeed" id="UpdateSeed" type="checkbox" <%=(Settings.UpdateSeed? "checked='checked'":"")%>>
                 <label class="settings-label" for="UpdateSeed"><%= i18n.__("Activate Update seeding") %></label>
             </span>
             <span class="advanced">
-                <input class="settings-checkbox" name="dhtEnable" id="dhtEnable" type="checkbox" <%=(Settings.dhtEnable? "checked='checked'":"")%>>
-                <label class="settings-label" for="dhtEnable"><%= i18n.__("Update config from internet") %></label>
-                <i style="padding-left:20px" class="update-dht fa fa-redo tooltipped" data-toggle="tooltip" data-placement="auto" title="<%= i18n.__("Update now") %>"></i>
+                <input class="settings-checkbox" name="events" id="events" type="checkbox" <%=(Settings.events? "checked='checked'":"")%>>
+                <label class="settings-label" for="events"><%= i18n.__("Celebrate various events") %></label>
             </span>
-            <!--span class="advanced"><-%=Settings.dhtData %-></span-->
         </div>
     </section>
 


### PR DESCRIPTION
Adds first-run* options for app and API automatic updates as well as 'Check now' buttons in the settings page.

*The disclaimer screen will show up if its the first run or if you've never set either (or both) of the automatic update options to enabled/disabled (e.g when updating from an older version where the option didn't exist, even if its not actually a first run)