### PR TITLE
Notification fix when user initiated API server update

### DIFF
--- a/src/app/dht.js
+++ b/src/app/dht.js
@@ -33,6 +33,8 @@ class DhtReader
                 App.vent.trigger('notification:close');
                 if (e === 'enable' || data !== newData) {
                     self.alertMessageSuccess(true);
+                } else if (e === 'manual') {
+                    self.alertMessageSuccess();
                 }
                 AdvSettings.set('dhtData', newData);
                 AdvSettings.set('dhtDataUpdated', Date.now());
@@ -74,6 +76,7 @@ class DhtReader
             notificationModel.set('body', i18n.__('Please restart your application'));
         } else {
             notificationModel.attributes.autoclose = 4000;
+            notificationModel.set('body', i18n.__('API Server URLs already updated'));
         }
 
         // Open the notification

--- a/src/app/lib/views/settings_container.js
+++ b/src/app/lib/views/settings_container.js
@@ -614,8 +614,7 @@
                     break;
                 case 'dhtEnable':
                     if (Settings.dhtEnable) {
-                        App.DhtReader.update('enable');
-                        this.alertMessageWait(i18n.__('Updating the API Server URLs'));
+                        this.updateDht('enable');
                     } else {
                         this.alertMessageSuccess(true);
                     }
@@ -664,8 +663,14 @@
             }
         },
 
-        updateDht: function() {
-            App.DhtReader.update();
+        updateDht: function(e) {
+            let updateMode = '';
+            if (e === 'enable') {
+                updateMode = e;
+            } else if (e) {
+                updateMode = 'manual';
+            }
+            App.DhtReader.update(updateMode);
             this.alertMessageWait(i18n.__('Updating the API Server URLs'));
         },
 


### PR DESCRIPTION
Before when the user clicked the 'Check for updates' button to update the API Servers it showed nothing if no new urls existed (only showed the success notification if new urls existed and were updated) which was a bit weird, user initiated actions should always show some response on the UI even if already updated. Now it will show a success notification with an already updated message to the user.