### PR TITLE
Add ext-player bin paths for NixOS

### DIFF
--- a/src/app/lib/device/ext-player.js
+++ b/src/app/lib/device/ext-player.js
@@ -232,6 +232,8 @@
     addPath('/usr/bin');
     addPath('/usr/local/bin');
     addPath('/snap/bin');
+    addPath(process.env.HOME + '/.nix-profile/bin'); // NixOS
+    addPath('/run/current-system/sw/bin'); // NixOS
     // darwin
     addPath('/Applications');
     addPath(process.env.HOME + '/Applications');


### PR DESCRIPTION
I'm currently [trying to package](https://github.com/NixOS/nixpkgs/pull/168121) popcorntime for NixOS.

This PR provides a patch for the external player logic, adding additional search paths which are required for NixOS.