### PR TITLE
Add VLC installed via Flatpak on Fedora 36

### DIFF
--- a/src/app/lib/device/ext-player.js
+++ b/src/app/lib/device/ext-player.js
@@ -158,7 +158,10 @@
             // "" So it behaves when spaces in path
             var cmd = '', cmdPath = '', cmdSwitch = '', cmdSub = '', cmdFs = '', cmdFilename = '', cmdUrl = '';
             var url = streamModel.attributes.src;
-            cmdPath += path.normalize('"' + this.get('path') + '" ');
+            
+            // A conditional check to see if VLC was installed via flatpak
+            this.get('path').includes('flatpak') && this.get('path').includes('VLC') ? cmdPath = '/usr/bin/flatpak run --branch=stable --arch=x86_64 --command=/app/bin/vlc org.videolan.VLC ' : cmdPath += path.normalize('"' + this.get('path') + '" ');
+            
             cmdSwitch += getPlayerSwitches(this.get('id')) + ' ';
 
             var subtitle = streamModel.attributes.subFile || '';
@@ -232,6 +235,7 @@
     addPath('/usr/bin');
     addPath('/usr/local/bin');
     addPath('/snap/bin');
+    addPath('/var/lib/flatpak/app/org.videolan.VLC/current/active'); //Fedora Flatpak VLC Dir
     addPath(process.env.HOME + '/.nix-profile/bin'); // NixOS
     addPath('/run/current-system/sw/bin'); // NixOS
     // darwin


### PR DESCRIPTION
Path added to see if VLC was added via Flatpak and a conditional statement to format the command accordingly