### PR TITLE
Fixed trakt get playback progress

### DIFF
--- a/src/app/lib/providers/trakttv.js
+++ b/src/app/lib/providers/trakttv.js
@@ -169,12 +169,12 @@
                 for (var r in results) {
                     var item = results[r];
                     var ids = item[item.type].ids;
-                    if ([ids.imdb, ids.tvdb].indexOf(id) !== -1) {
+                    if ([ids.imdb?.toString(), ids.tvdb?.toString()].indexOf(id.toString()) !== -1) {
                         return item.progress;
                     }
                 }
                 return 0;
-            });
+            }.bind(this));
         },
 
         scrobble: function(action, type, id, progress) {


### PR DESCRIPTION
getPlayback was missing the function context and always returned 0.
`toString()` is necessary since imdb is a string and tvdb a number.