### PR TITLE
Brightness contrast fix 2

### DIFF
--- a/src/app/lib/views/player/player.js
+++ b/src/app/lib/views/player/player.js
@@ -782,9 +782,9 @@
         adjustHue: function (difference) {
             this.filters.hue += difference;
             if (this.filters.hue < -180) {
-                this.filters.hue = -180;
+                this.filters.hue += 360;
             } else if (this.filters.hue > 180) {
-                this.filters.hue = 180;
+                this.filters.hue -= 360;
             }
             this.applyFilters();
             this.displayOverlayMsg(i18n.__('Hue') + ': ' + this.filters.hue.toFixed(0));

--- a/src/app/lib/views/player/player.js
+++ b/src/app/lib/views/player/player.js
@@ -807,7 +807,12 @@
             // On some devices, the image turns orange if both hue-rotate() and saturate() are used!
             // So we only add the hue-rotate() filter if requested by the user.
             const hueAdjustment = hue === 0 ? '' : `hue-rotate(${hue}deg)`;
-            curVideo[0].style.filter = `brightness(${brightness}) contrast(${contrast}) ${hueAdjustment} saturate(${saturation})`;
+            // By default, increasing brightness in HTML5 also visually increases saturation and contrast
+            // To match other players, we reduce contrast and saturation, to keep the other filters steady
+            const deltaB = brightness - 1.0;
+            const finalContrast = contrast - deltaB * 0.333;
+            const finalSaturation = saturation - deltaB * 0.5;
+            curVideo[0].style.filter = `brightness(${brightness}) contrast(${finalContrast}) ${hueAdjustment} saturate(${finalSaturation})`;
         },
 
         bindKeyboardShortcuts: function () {


### PR DESCRIPTION
Small improvements to user experience.

I wrote this shortly after the original brightness-contrast merge, but I forgot to share it, so here it is now.

**Problem**: When adjusting brightness, the HTML5 video filters tend to visually increase contrast and saturation as well. This can result in images with the whites maxxing out and the colours becoming too strong.

**Theory**: What users usually want when increasing the brightness, is to actually increase the _gamma_, so that darks get brighter, but the top whites do not all max out. And colours should remain at about the same saturation.

**Solution**: Although gamma is not currently offered by CSS filters, we can approximate it. This code simply adjusts the contrast and the saturation to compensate for the unwanted changes caused when adjusting the brightness. This makes it feel to me more like SMPlayer's brightness filter.

Additional: I also made it so that hue will wrap around, if you go too far in one direction.