### PR TITLE
Dynamically adjust Favorites tab types to enabled tabs

### DIFF
--- a/src/app/lib/providers/favorites.js
+++ b/src/app/lib/providers/favorites.js
@@ -189,10 +189,19 @@
     };
 
     Favorites.prototype.filters = function () {
-        const data = {
-            types: ['All', 'Movies', 'Series', 'Anime'],
+        let data = {
+            types: ['All'],
             sorters: ['watched items', 'year', 'title', 'rating']
         };
+        if (Settings.moviesTabEnable) {
+            data.types.push('Movies');
+        }
+        if (Settings.seriesTabEnable) {
+            data.types.push('Series');
+        }
+        if (Settings.animeTabEnable) {
+            data.types.push('Anime');
+        }
         let filters = {
             types: {},
             sorters: {},


### PR DESCRIPTION
At the moment you can still select a type in the Favorites tab which has been disabled in settings, this PR disables this behavior.