### PR TITLE
Added selector to filter watched movies instead of bookmarked ones in the Favorites tab

### DIFF
--- a/src/app/database.js
+++ b/src/app/database.js
@@ -118,6 +118,20 @@ var Database = {
         return db.bookmarks.find(query).skip(offset).limit(byPage);
     },
 
+    // format: {page: page, keywords: title}
+    getWatched: function (data) {
+        var page = data.page - 1;
+        var byPage = 500;
+        var offset = page * byPage;
+        var query = {};
+
+        if (data.type) {
+            query.type = data.type;
+        }
+
+        return db.watched.find(query).skip(offset).limit(byPage);
+    },
+
     getAllBookmarks: function () {
         return db.bookmarks.find({});
     },

--- a/src/app/language/en.json
+++ b/src/app/language/en.json
@@ -571,5 +571,7 @@
 	"Updates": "Updates",
 	"Trending": "Trending",
 	"Popularity": "Popularity",
-	"Last Added": "Last Added"
+	"Last Added": "Last Added",
+	"Kind": "Kind",
+	"Watched": "Watched"
 }

--- a/src/app/lib/models/filter.js
+++ b/src/app/lib/models/filter.js
@@ -7,6 +7,7 @@
             this.set('load', false);
             this.set('genres', []);
             this.set('sorters', []);
+            this.set('kinds', []);
             this.set('types', []);
             this.set('ratings', []);
             this.init();
@@ -14,6 +15,7 @@
             this.get('provider').filters().then((filters) => {
                 this.set('genres', filters.genres || []);
                 this.set('sorters', filters.sorters || []);
+                this.set('kinds', filters.kinds || []);
                 this.set('types', filters.types || []);
                 this.set('ratings', filters.ratings || []);
 
@@ -26,6 +28,7 @@
         init() {
             this.set('sorter', this.get('sorter') || Object.keys(this.get('sorters'))[0]);
             this.set('genre', this.get('genre') || Object.keys(this.get('genres'))[0]);
+            this.set('kind', this.get('kind') || Object.keys(this.get('kinds'))[0]);
             this.set('type', this.get('type') || Object.keys(this.get('types'))[0]);
             this.set('order', this.get('order') || -1);
             this.set('rating', this.get('rating') || Object.keys(this.get('ratings'))[0]);

--- a/src/app/lib/views/browser/filter_bar.js
+++ b/src/app/lib/views/browser/filter_bar.js
@@ -10,6 +10,7 @@
       search: '.search',
       searchClear: '.search .clear',
       sorterValue: '.sorters .value',
+      kindValue: '.kinds .value',
       typeValue: '.types .value',
       genreValue: '.genres .value',
       ratingValue: '.ratings .value'
@@ -22,6 +23,7 @@
       'click  @ui.search': 'focusSearch',
       'click .sorters .dropdown-menu a': 'sortBy',
       'click .genres .dropdown-menu a': 'changeGenre',
+      'click .kinds .dropdown-menu a': 'changeKind',
       'click .types .dropdown-menu a': 'changeType',
       'click .ratings .dropdown-menu a': 'changeRating',
       'click #filterbar-settings': 'settings',
@@ -333,6 +335,22 @@
       this.model.set({
         keyword: '',
         rating: rating
+      });
+    },
+
+    changeKind: function(e) {
+      App.vent.trigger('about:close');
+      App.vent.trigger('torrentCollection:close');
+      App.vent.trigger('seedbox:close');
+      this.$('.kinds .active').removeClass('active');
+      $(e.target).addClass('active');
+
+      var kind = $(e.target).attr('data-value');
+      this.ui.kindValue.text($(e.target).text());
+
+      this.model.set({
+        keyword: '',
+        kind: kind
       });
     },
 

--- a/src/app/templates/browser/filter-bar.tpl
+++ b/src/app/templates/browser/filter-bar.tpl
@@ -18,6 +18,7 @@
 </ul>
 <ul id="nav-filters" class="nav nav-hor filters">
     <% filters = [
+        {class: 'kinds', title:  "Kind", current: kind, list: kinds},
         {class: 'types', title: "Type", current: type, list: types},
         {class: 'ratings', title:  "Rating", current: rating, list: ratings},
         {class: 'genres', title:  "Genre", current: genre, list: genres},


### PR DESCRIPTION
This closes #2347.
Full disclaimer: This commit is implemented in a way which may not please the maintainers. (Reasons follow)
- The watched filter is inside of the Favorites tab. This is done in order to have multiple instances of the same code.
- A new drop-down named "Kind" has been added. I couldn't think of a better name, given that "Type" was already used.
- The information of the watched items is not cached in the local database. This is done because if it were, the size of the database would considerably increase.
- Code-wise, the commit references functions as variables, which some coders do not like. In this case, it avoids having multiple instances of existing code or creating new functions.

I'll attempt to adapt the code if the maintainers so wish.