### PR TITLE
Turn the new Watched filter into a Watched tab

### DIFF
--- a/src/app/lib/providers/favorites.js
+++ b/src/app/lib/providers/favorites.js
@@ -10,12 +10,15 @@
     };
 
     var queryTorrents = function (filters) {
-        let query_func = App.db.getBookmarks; // default to favorites
-        if (filters.kind === 'Watched') {
+        let query_func;
+        if (App.currentview === 'Watched') {
+            filters.kind = 'Watched';
             query_func = App.db.getWatched;
             if (filters.type === 'show') {
                 filters.type = 'episode';
             }
+        } else {
+            query_func = App.db.getBookmarks; // default to favorites
         }
         return query_func(filters)
             .then(function (data) {
@@ -230,6 +233,9 @@
     };
 
     Favorites.prototype.fetch = function (filters) {
+        if (App.currentview === 'Watched') {
+            filters.kind = 'Watched';
+        }
         var params = {
             page: filters.page,
             kind: filters.kind

--- a/src/app/lib/views/browser/filter_bar.js
+++ b/src/app/lib/views/browser/filter_bar.js
@@ -10,7 +10,6 @@
       search: '.search',
       searchClear: '.search .clear',
       sorterValue: '.sorters .value',
-      kindValue: '.kinds .value',
       typeValue: '.types .value',
       genreValue: '.genres .value',
       ratingValue: '.ratings .value'
@@ -23,7 +22,6 @@
       'click  @ui.search': 'focusSearch',
       'click .sorters .dropdown-menu a': 'sortBy',
       'click .genres .dropdown-menu a': 'changeGenre',
-      'click .kinds .dropdown-menu a': 'changeKind',
       'click .types .dropdown-menu a': 'changeType',
       'click .ratings .dropdown-menu a': 'changeRating',
       'click #filterbar-settings': 'settings',
@@ -32,6 +30,7 @@
       'click .tvshowTabShow': 'tvshowTabShow',
       'click .animeTabShow': 'animeTabShow',
       'click #filterbar-favorites': 'showFavorites',
+      'click #filterbar-watched': 'showWatched',
       'click #filterbar-watchlist': 'showWatchlist',
       'click #filterbar-torrent-collection': 'showTorrentCollection',
       'click .triggerUpdate': 'updateDB',
@@ -84,6 +83,10 @@
         case 'Favorites':
         case 'favorites':
           $('#filterbar-favorites').addClass('active');
+          break;
+        case 'Watched':
+        case 'watched':
+          $('#filterbar-watched').addClass('active');
           break;
         case 'Watchlist':
         case 'watchlist':
@@ -169,6 +172,10 @@
             break;
           case 'Favorites':
             App.currentview = 'Favorites';
+            App.previousview = 'movies';
+            break;
+          case 'Watched':
+            App.currentview = 'Watched';
             App.previousview = 'movies';
             break;
           case 'Watchlist':
@@ -338,22 +345,6 @@
       });
     },
 
-    changeKind: function(e) {
-      App.vent.trigger('about:close');
-      App.vent.trigger('torrentCollection:close');
-      App.vent.trigger('seedbox:close');
-      this.$('.kinds .active').removeClass('active');
-      $(e.target).addClass('active');
-
-      var kind = $(e.target).attr('data-value');
-      this.ui.kindValue.text($(e.target).text());
-
-      this.model.set({
-        keyword: '',
-        kind: kind
-      });
-    },
-
     settings: function(e) {
       App.vent.trigger('about:close');
       App.vent.trigger('settings:show');
@@ -440,6 +431,17 @@
       App.vent.trigger('seedbox:close');
       App.vent.trigger('favorites:list', []);
       this.setActive('Favorites');
+    },
+
+    showWatched: function(e) {
+      e.preventDefault();
+      App.previousview = App.currentview;
+      App.currentview = 'Watched';
+      App.vent.trigger('about:close');
+      App.vent.trigger('torrentCollection:close');
+      App.vent.trigger('seedbox:close');
+      App.vent.trigger('favorites:list', []);
+      this.setActive('Watched');
     },
 
     showWatchlist: function(e) {

--- a/src/app/lib/views/browser/item.js
+++ b/src/app/lib/views/browser/item.js
@@ -144,17 +144,19 @@
             if (this.model.get('watched') && !itemtype.match('show')) {
                 this.ui.watchedIcon.addClass('selected');
 
-                switch (Settings.watchedCovers) {
-                    case 'fade':
-                        this.$el.addClass('watched');
-                        break;
-                    case 'hide':
-                        if ($('.search input').val() || itemtype.match('bookmarked')) {
+                if (App.currentview !== 'Watched') {
+                    switch (Settings.watchedCovers) {
+                        case 'fade':
                             this.$el.addClass('watched');
-                        } else {
-                            this.$el.remove();
-                        }
-                        break;
+                            break;
+                        case 'hide':
+                            if ($('.search input').val() || itemtype.match('bookmarked')) {
+                                this.$el.addClass('watched');
+                            } else {
+                                this.$el.remove();
+                            }
+                            break;
+                    }
                 }
             }
 

--- a/src/app/lib/views/browser/list.js
+++ b/src/app/lib/views/browser/list.js
@@ -173,6 +173,9 @@
             if (Settings.favoritesTabEnable) {
                 filterBarElem.push('Favorites');
             }
+            if (Settings.watchedTabEnable) {
+                filterBarElem.push('Watched');
+            }
 
             _this.initKeyboardShortcuts();
 
@@ -228,32 +231,44 @@
                         }
                     }
                     App.currentview = filterBarElem[filterBarPos];
-                    App.vent.trigger(App.currentview.toLowerCase() + ':list', []);
+                    if (App.currentview === 'Watched') {
+                        App.vent.trigger('favorites:list', []);
+                    } else {
+                        App.vent.trigger(App.currentview.toLowerCase() + ':list', []);
+                    }
                     if (App.currentview === 'movies') {
                         $('.source.movieTabShow').addClass('active');
                     } else if (App.currentview === 'shows') {
                             $('.source.tvshowTabShow').addClass('active');
                     } else if (App.currentview === 'Favorites') {
                             $('#filterbar-favorites').addClass('active');
+                    } else if (App.currentview === 'Watched') {
+                            $('#filterbar-watched').addClass('active');
                     } else {
                             $('.source.' + App.currentview + 'TabShow').addClass('active');
                     }
                 }
             });
 
-            Mousetrap.bind(['ctrl+1', 'ctrl+2', 'ctrl+3', 'ctrl+4'], function (e, combo) {
+            Mousetrap.bind(['ctrl+1', 'ctrl+2', 'ctrl+3', 'ctrl+4', 'ctrl+5'], function (e, combo) {
                 if ((App.PlayerView === undefined || App.PlayerView.isDestroyed) && $('#about-container').children().length <= 0 && $('#player').children().length <= 0 && combo.charAt(5) <= $(filterBarElem).toArray().length && App.currentview !== filterBarElem[combo.charAt(5) - 1]) {
                     App.vent.trigger('torrentCollection:close');
                     App.vent.trigger('seedbox:close');
                     $('.filter-bar').find('.active').removeClass('active');
                     App.currentview = filterBarElem[combo.charAt(5) - 1];
-                    App.vent.trigger(App.currentview.toLowerCase() + ':list', []);
+                    if (App.currentview === 'Watched') {
+                        App.vent.trigger('favorites:list', []);
+                    } else {
+                        App.vent.trigger(App.currentview.toLowerCase() + ':list', []);
+                    }
                     if (App.currentview === 'movies') {
                         $('.source.movieTabShow').addClass('active');
                     } else if (App.currentview === 'shows') {
                         $('.source.tvshowTabShow').addClass('active');
                     } else if (App.currentview === 'Favorites') {
                         $('#filterbar-favorites').addClass('active');
+                    } else if (App.currentview === 'Watched') {
+                        $('#filterbar-watched').addClass('active');
                     } else {
                         $('.source.' + App.currentview + 'TabShow').addClass('active');
                     }

--- a/src/app/lib/views/settings_container.js
+++ b/src/app/lib/views/settings_container.js
@@ -356,6 +356,7 @@
                 case 'seriesTabEnable':
                 case 'animeTabEnable':
                 case 'favoritesTabEnable':
+                case 'watchedTabEnable':
                     value = field.is(':checked');
                     break;
                 case 'httpApiEnabled':
@@ -581,6 +582,14 @@
                     $('.nav-hor.left li:first').click();
                     App.vent.trigger('settings:show');
                     if (AdvSettings.get('startScreen') === 'Favorites') {
+                        $('select[name=start_screen]').change();
+                    }
+                    break;
+                case 'watchedTabEnable':
+                    App.vent.trigger('favorites:list');
+                    $('.nav-hor.left li:first').click();
+                    App.vent.trigger('settings:show');
+                    if (AdvSettings.get('startScreen') === 'Watched') {
                         $('select[name=start_screen]').change();
                     }
                     break;

--- a/src/app/settings.js
+++ b/src/app/settings.js
@@ -98,6 +98,7 @@ Settings.moviesTabEnable = true;
 Settings.seriesTabEnable = true;
 Settings.animeTabEnable = true;
 Settings.favoritesTabEnable = true;
+Settings.watchedTabEnable = true;
 Settings.coversShowRating = true;
 Settings.showSeedboxOnDlInit = true;
 Settings.expandedSearch = false;

--- a/src/app/templates/browser/filter-bar.tpl
+++ b/src/app/templates/browser/filter-bar.tpl
@@ -15,10 +15,16 @@
     <% } %>
         <%= i18n.__("Favorites") %>
     </li>
+    <% if (Settings.watchedTabEnable) { %>
+    <li id="filterbar-watched" class="source" style="display:block">
+    <% } else { %>
+    <li id="filterbar-watched" class="source" style="display:none">
+    <% } %>
+        <%= i18n.__("Watched") %>
+    </li>
 </ul>
 <ul id="nav-filters" class="nav nav-hor filters">
     <% filters = [
-        {class: 'kinds', title:  "Kind", current: kind, list: kinds},
         {class: 'types', title: "Type", current: type, list: types},
         {class: 'ratings', title:  "Rating", current: rating, list: ratings},
         {class: 'genres', title:  "Genre", current: genre, list: genres},

--- a/src/app/templates/settings-container.tpl
+++ b/src/app/templates/settings-container.tpl
@@ -51,6 +51,7 @@
                             Settings.seriesTabEnable ? arr_screens.push("TV Series") : null;
                             Settings.animeTabEnable ? arr_screens.push("Anime") : null;
                             Settings.favoritesTabEnable ? arr_screens.push("Favorites") : null;
+                            Settings.watchedTabEnable ? arr_screens.push("Watched") : null;
                             Settings.activateWatchlist && App.Trakt.authenticated ? arr_screens.push("Watchlist") : null;
                             Settings.activateTorrentCollection ? arr_screens.push("Torrent-collection") : null;
                             Settings.activateSeedbox ? arr_screens.push("Seedbox") : null;
@@ -78,6 +79,9 @@
                 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
                 <input class="settings-checkbox" name="favoritesTabEnable" id="favoritesTabEnable" type="checkbox" <%=(Settings.favoritesTabEnable? "checked='checked'":"")%>>
                 <label class="settings-label" for="favoritesTabEnable"><%= i18n.__("Favorites") %></label>
+                &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+                <input class="settings-checkbox" name="watchedTabEnable" id="watchedTabEnable" type="checkbox" <%=(Settings.watchedTabEnable? "checked='checked'":"")%>>
+                <label class="settings-label" for="watchedTabEnable"><%= i18n.__("Watched") %></label>
             </span>
             <span>
                 <input class="settings-checkbox" name="coversShowRating" id="coversShowRating" type="checkbox" <%=(Settings.coversShowRating? "checked='checked'":"")%>>


### PR DESCRIPTION
*almost all of the work for this was done by @El-Virus with #2774. I just turned it into a tab for better uniformity, easier access and the ability to disable it if needed like we can with the rest of the tabs.